### PR TITLE
Add EIP-8070 Engine API surface: engine_getBlobsV4 and custodyColumns

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -50,6 +50,7 @@ public enum RpcMethod {
   ENGINE_GET_BLOBS_V1("engine_getBlobsV1"),
   ENGINE_GET_BLOBS_V2("engine_getBlobsV2"),
   ENGINE_GET_BLOBS_V3("engine_getBlobsV3"),
+  ENGINE_GET_BLOBS_V4("engine_getBlobsV4"),
   ENGINE_GET_PAYLOAD_V1("engine_getPayloadV1"),
   ENGINE_GET_PAYLOAD_V2("engine_getPayloadV2"),
   ENGINE_GET_PAYLOAD_V3("engine_getPayloadV3"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -62,7 +63,8 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       EngineCallListener engineCallListener,
       MergeMiningCoordinator mergeCoordinator,
       EthPeers ethPeers,
-      MetricsSystem metricsSystem) {}
+      MetricsSystem metricsSystem,
+      TransactionPool transactionPool) {}
 
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionEngineJsonRpcMethod.class);
   public static final long ENGINE_API_LOGGING_THRESHOLD = 60000L;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -27,9 +27,10 @@ import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcRequestException;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceStateV1;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceUpdatedRequestParametersV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttributesV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
@@ -53,11 +54,21 @@ import org.slf4j.LoggerFactory;
  * the full FCU implementation; later versions extend and override specific hooks to introduce their
  * own concepts without modifying this class.
  *
+ * <p>Parameter parsing follows the same shape as {@code engine_newPayload}'s {@code
+ * NewPayloadRequestParametersV*} hierarchy: {@link #readRequestParameters(JsonRpcRequestContext)}
+ * is called once per request and decorates the previous version's params object with any new fields
+ * a version adds (see {@link EngineForkchoiceUpdatedV4} for the {@code custodyColumns} example), so
+ * {@link #syncResponse(JsonRpcRequestContext)} works off one typed object instead of reading {@code
+ * requestContext} directly.
+ *
  * <p>Parameterized so that V2 can extend this class while narrowing the payload type.
  *
  * @param <PA> the payload-attributes type this version accepts
+ * @param <FRP> the request-parameters type this version reads
  */
-public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
+public sealed class EngineForkchoiceUpdatedV1<
+        PA extends PayloadAttributesV1,
+        FRP extends ForkchoiceUpdatedRequestParametersV1<? extends PA>>
     extends ExecutionEngineJsonRpcMethod permits EngineForkchoiceUpdatedV2 {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV1.class);
@@ -93,29 +104,17 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
 
     final Object requestId = requestContext.getRequest().getId();
 
-    final ForkchoiceStateV1 forkChoice;
+    final FRP requestParameters;
     try {
-      forkChoice = requestContext.getRequiredParameter(0, ForkchoiceStateV1.class);
-    } catch (JsonRpcParameter.JsonRpcParameterException e) {
-      throw new InvalidJsonRpcParameters(
-          "Invalid forkchoice state parameter (index 0)",
-          RpcErrorType.INVALID_ENGINE_FORKCHOICE_UPDATED_PARAMS,
-          e);
+      requestParameters = readRequestParameters(requestContext);
+    } catch (final InvalidRequestParametersException e) {
+      return new JsonRpcErrorResponse(requestId, e.getRpcErrorType());
     }
 
-    logger().debug("Forkchoice parameters {}", forkChoice);
+    applyRequestParameters(requestParameters);
 
-    final Optional<PA> maybePayloadAttributes;
-    try {
-      maybePayloadAttributes =
-          requestContext.getOptionalParameter(
-              1, getPayloadAttributesClass(), FAIL_ON_UNKNOWN_BUT_NULL);
-    } catch (JsonRpcParameter.JsonRpcParameterException e) {
-      logger().debug("Invalid payload attributes parameter", e);
-      return new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError());
-    }
-
-    logger().debug("Payload attributes {}", maybePayloadAttributes);
+    final ForkchoiceStateV1 forkChoice = requestParameters.forkchoiceState();
+    final Optional<? extends PA> maybePayloadAttributes = requestParameters.payloadAttributes();
 
     // Structural parameter check (-32602) — must happen before any FCU processing.
     final ValidationResult<RpcErrorType> structResult = validateForkchoiceStateParams(forkChoice);
@@ -261,6 +260,48 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
             payloadId));
   }
 
+  /**
+   * Reads and decodes this version's request parameters. Each version overrides this to call {@code
+   * super.readRequestParameters(...)} and decorate the result with its own additional parameter(s),
+   * mirroring {@code EngineNewPayloadVN.readRequestParameters(...)}.
+   */
+  @SuppressWarnings("unchecked")
+  protected FRP readRequestParameters(final JsonRpcRequestContext requestContext) {
+    final ForkchoiceStateV1 forkChoice;
+    try {
+      forkChoice = requestContext.getRequiredParameter(0, ForkchoiceStateV1.class);
+    } catch (JsonRpcParameter.JsonRpcParameterException e) {
+      throw new InvalidRequestParametersException(
+          "Invalid forkchoice state parameter (index 0)",
+          RpcErrorType.INVALID_ENGINE_FORKCHOICE_UPDATED_PARAMS,
+          e);
+    }
+
+    logger().debug("Forkchoice parameters {}", forkChoice);
+
+    final Optional<PA> maybePayloadAttributes;
+    try {
+      maybePayloadAttributes =
+          requestContext.getOptionalParameter(
+              1, getPayloadAttributesClass(), FAIL_ON_UNKNOWN_BUT_NULL);
+    } catch (JsonRpcParameter.JsonRpcParameterException e) {
+      throw new InvalidRequestParametersException(
+          "Invalid payload attributes parameter (index 1)", getInvalidPayloadAttributesError(), e);
+    }
+
+    logger().debug("Payload attributes {}", maybePayloadAttributes);
+
+    return (FRP) new ForkchoiceUpdatedRequestParametersV1<>(forkChoice, maybePayloadAttributes);
+  }
+
+  /**
+   * Applies any side effect a version's additional request parameter(s) require, called once right
+   * after a successful {@link #readRequestParameters(JsonRpcRequestContext)} and before any FCU
+   * processing. Default: no-op. See {@link EngineForkchoiceUpdatedV4} for the {@code
+   * custodyColumns} override.
+   */
+  protected void applyRequestParameters(final FRP requestParameters) {}
+
   /** Validates version-specific payload attributes field requirements. */
   protected ValidationResult<RpcErrorType> validatePayloadAttributes(
       final BlockHeader newHead, final PA attrs) {
@@ -383,5 +424,16 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
             forkChoice.getHeadBlockHash().toShortLogString(),
             forkChoice.getSafeBlockHash().toShortLogString(),
             forkChoice.getFinalizedBlockHash().toShortLogString());
+  }
+
+  protected static class InvalidRequestParametersException extends InvalidJsonRpcRequestException {
+    InvalidRequestParametersException(final String message, final RpcErrorType rpcErrorType) {
+      super(message, rpcErrorType);
+    }
+
+    InvalidRequestParametersException(
+        final String message, final RpcErrorType rpcErrorType, final Throwable cause) {
+      super(message, rpcErrorType, cause);
+    }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import org.hyperledger.besu.consensus.merge.blockcreation.PreparePayloadArgsBuilder;
 import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceUpdatedRequestParametersV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttributesV2;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -36,8 +37,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Parameterized so that V3 can extend this class while narrowing the payload type.
  */
-public sealed class EngineForkchoiceUpdatedV2<PA extends PayloadAttributesV2>
-    extends EngineForkchoiceUpdatedV1<PA> permits EngineForkchoiceUpdatedV3 {
+public sealed class EngineForkchoiceUpdatedV2<
+        PA extends PayloadAttributesV2,
+        FRP extends ForkchoiceUpdatedRequestParametersV1<? extends PA>>
+    extends EngineForkchoiceUpdatedV1<PA, FRP> permits EngineForkchoiceUpdatedV3 {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV2.class);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import org.hyperledger.besu.consensus.merge.blockcreation.PreparePayloadArgsBuilder;
 import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceUpdatedRequestParametersV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttributesV3;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -33,8 +34,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Parameterized so that V4 can extend this class while narrowing the payload type.
  */
-public sealed class EngineForkchoiceUpdatedV3<PA extends PayloadAttributesV3>
-    extends EngineForkchoiceUpdatedV2<PA> permits EngineForkchoiceUpdatedV4 {
+public sealed class EngineForkchoiceUpdatedV3<
+        PA extends PayloadAttributesV3,
+        FRP extends ForkchoiceUpdatedRequestParametersV1<? extends PA>>
+    extends EngineForkchoiceUpdatedV2<PA, FRP> permits EngineForkchoiceUpdatedV4 {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV3.class);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
@@ -18,10 +18,10 @@ import org.hyperledger.besu.consensus.merge.blockcreation.PreparePayloadArgsBuil
 import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceUpdatedRequestParametersV1;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceUpdatedRequestParametersV2;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttributesV4;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
@@ -34,9 +34,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@code engine_forkchoiceUpdatedV4} — Amsterdam (EIP-7843 Slot Number).
+ * {@code engine_forkchoiceUpdatedV4} — Amsterdam (EIP-7843 Slot Number, EIP-8070 Custody Columns).
  *
  * <p>Extends V3 with {@link PayloadAttributesV4}, adding the mandatory {@code slotNumber} field.
+ * Also adds an optional {@code custodyColumns} 3rd top-level request parameter (EIP-8070), handled
+ * via {@link #readRequestParameters(JsonRpcRequestContext)} / {@link
+ * #applyRequestParameters(ForkchoiceUpdatedRequestParametersV2)} rather than a {@code syncResponse}
+ * override — see {@link EngineForkchoiceUpdatedV1}'s class Javadoc for the parameter-parsing
+ * pattern this follows.
  *
  * <p>Parameterized so that a future V5 can extend this class without modifying it (beyond updating
  * the upper-bound fork in the public constructor below).
@@ -46,13 +51,15 @@ import org.slf4j.LoggerFactory;
  * <ol>
  *   <li>Create {@code PayloadAttributesV5 extends PayloadAttributesV4} with the new field.
  *   <li>Create {@code EngineForkchoiceUpdatedV5 extends
- *       EngineForkchoiceUpdatedV4<PayloadAttributesV5>}.
+ *       EngineForkchoiceUpdatedV4<PayloadAttributesV5, ...>}.
  *   <li>Update the public constructor below: change {@code Optional.empty()} to {@code
  *       Optional.of(V5_FORK)}.
  * </ol>
  */
-public final class EngineForkchoiceUpdatedV4<PA extends PayloadAttributesV4>
-    extends EngineForkchoiceUpdatedV3<PA> {
+public final class EngineForkchoiceUpdatedV4<
+        PA extends PayloadAttributesV4,
+        FRP extends ForkchoiceUpdatedRequestParametersV2<? extends PA>>
+    extends EngineForkchoiceUpdatedV3<PA, FRP> {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV4.class);
   private static final int CUSTODY_COLUMNS_BYTE_LENGTH = 16;
@@ -78,47 +85,55 @@ public final class EngineForkchoiceUpdatedV4<PA extends PayloadAttributesV4>
   }
 
   /**
-   * V4 adds an optional {@code custodyColumns} 3rd parameter (Amsterdam / EIP-8070). Its validation
-   * and adoption is handled here, independently of and before the rest of the FCU flow, then
-   * delegates to V1's {@code syncResponse} unchanged.
+   * V4 adds an optional {@code custodyColumns} 3rd parameter (Amsterdam / EIP-8070): reads and
+   * shape-validates it (16 bytes if present), decorating V1..V3's request parameters.
    */
   @Override
-  public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
-    final ValidationResult<RpcErrorType> custodyColumnsResult =
-        validateAndApplyCustodyColumns(requestContext);
-    if (!custodyColumnsResult.isValid()) {
-      return new JsonRpcErrorResponse(requestContext.getRequest().getId(), custodyColumnsResult);
-    }
-    return super.syncResponse(requestContext);
+  @SuppressWarnings("unchecked")
+  protected FRP readRequestParameters(final JsonRpcRequestContext requestContext) {
+    final ForkchoiceUpdatedRequestParametersV1<? extends PA> requestParameters =
+        super.readRequestParameters(requestContext);
+    final Optional<Bytes> custodyColumns = readCustodyColumns(requestContext);
+    return (FRP) new ForkchoiceUpdatedRequestParametersV2<>(requestParameters, custodyColumns);
   }
 
-  private ValidationResult<RpcErrorType> validateAndApplyCustodyColumns(
-      final JsonRpcRequestContext requestContext) {
+  private Optional<Bytes> readCustodyColumns(final JsonRpcRequestContext requestContext) {
     final Optional<Bytes> custodyColumns;
     try {
       custodyColumns = requestContext.getOptionalParameter(2, Bytes.class);
     } catch (JsonRpcParameter.JsonRpcParameterException e) {
-      return ValidationResult.invalid(
+      throw new InvalidRequestParametersException(
+          "Invalid custodyColumns parameter (index 2)",
           RpcErrorType.INVALID_CUSTODY_COLUMNS_PARAMS,
-          "Invalid custodyColumns parameter (index 2)");
+          e);
     }
-    if (custodyColumns.isEmpty()) {
-      return ValidationResult.valid();
-    }
-    final Bytes bytes = custodyColumns.get();
-    if (bytes.size() != CUSTODY_COLUMNS_BYTE_LENGTH) {
-      return ValidationResult.invalid(
-          RpcErrorType.INVALID_CUSTODY_COLUMNS_PARAMS,
+    if (custodyColumns.isPresent() && custodyColumns.get().size() != CUSTODY_COLUMNS_BYTE_LENGTH) {
+      throw new InvalidRequestParametersException(
           "custodyColumns must be %d bytes, got %d"
-              .formatted(CUSTODY_COLUMNS_BYTE_LENGTH, bytes.size()));
+              .formatted(CUSTODY_COLUMNS_BYTE_LENGTH, custodyColumns.get().size()),
+          RpcErrorType.INVALID_CUSTODY_COLUMNS_PARAMS);
     }
-    // Custody set adoption MUST NOT affect the main forkchoice-update processing flow.
-    try {
-      transactionPool.updateBlobCustodyColumns(bytes);
-    } catch (final RuntimeException e) {
-      logger().warn("Failed to adopt updated blob custody columns", e);
-    }
-    return ValidationResult.valid();
+    return custodyColumns;
+  }
+
+  /**
+   * Adopts {@code custodyColumns} into {@link TransactionPool} when present. Custody-set adoption
+   * MUST NOT affect the main forkchoice-update processing flow, so failures here are logged and
+   * swallowed rather than propagated.
+   */
+  @Override
+  protected void applyRequestParameters(final FRP requestParameters) {
+    super.applyRequestParameters(requestParameters);
+    requestParameters
+        .custodyColumns()
+        .ifPresent(
+            custodyColumns -> {
+              try {
+                transactionPool.updateBlobCustodyColumns(custodyColumns);
+              } catch (final RuntimeException e) {
+                logger().warn("Failed to adopt updated blob custody columns", e);
+              }
+            });
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
@@ -17,11 +17,19 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import org.hyperledger.besu.consensus.merge.blockcreation.PreparePayloadArgsBuilder;
 import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttributesV4;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +55,9 @@ public final class EngineForkchoiceUpdatedV4<PA extends PayloadAttributesV4>
     extends EngineForkchoiceUpdatedV3<PA> {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV4.class);
+  private static final int CUSTODY_COLUMNS_BYTE_LENGTH = 16;
+
+  private final TransactionPool transactionPool;
 
   @Override
   protected Logger logger() {
@@ -58,11 +69,56 @@ public final class EngineForkchoiceUpdatedV4<PA extends PayloadAttributesV4>
       final HardforkId minFork,
       final HardforkId maxFork) {
     super(constructorArguments, minFork, maxFork);
+    this.transactionPool = constructorArguments.transactionPool();
   }
 
   @Override
   public String getName() {
     return RpcMethod.ENGINE_FORKCHOICE_UPDATED_V4.getMethodName();
+  }
+
+  /**
+   * V4 adds an optional {@code custodyColumns} 3rd parameter (Amsterdam / EIP-8070). Its validation
+   * and adoption is handled here, independently of and before the rest of the FCU flow, then
+   * delegates to V1's {@code syncResponse} unchanged.
+   */
+  @Override
+  public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
+    final ValidationResult<RpcErrorType> custodyColumnsResult =
+        validateAndApplyCustodyColumns(requestContext);
+    if (!custodyColumnsResult.isValid()) {
+      return new JsonRpcErrorResponse(requestContext.getRequest().getId(), custodyColumnsResult);
+    }
+    return super.syncResponse(requestContext);
+  }
+
+  private ValidationResult<RpcErrorType> validateAndApplyCustodyColumns(
+      final JsonRpcRequestContext requestContext) {
+    final Optional<Bytes> custodyColumns;
+    try {
+      custodyColumns = requestContext.getOptionalParameter(2, Bytes.class);
+    } catch (JsonRpcParameter.JsonRpcParameterException e) {
+      return ValidationResult.invalid(
+          RpcErrorType.INVALID_CUSTODY_COLUMNS_PARAMS,
+          "Invalid custodyColumns parameter (index 2)");
+    }
+    if (custodyColumns.isEmpty()) {
+      return ValidationResult.valid();
+    }
+    final Bytes bytes = custodyColumns.get();
+    if (bytes.size() != CUSTODY_COLUMNS_BYTE_LENGTH) {
+      return ValidationResult.invalid(
+          RpcErrorType.INVALID_CUSTODY_COLUMNS_PARAMS,
+          "custodyColumns must be %d bytes, got %d"
+              .formatted(CUSTODY_COLUMNS_BYTE_LENGTH, bytes.size()));
+    }
+    // Custody set adoption MUST NOT affect the main forkchoice-update processing flow.
+    try {
+      transactionPool.updateBlobCustodyColumns(bytes);
+    } catch (final RuntimeException e) {
+      logger().warn("Failed to adopt updated blob custody columns", e);
+    }
+    return ValidationResult.valid();
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
+
+import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.VersionedHash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobCellsAndProofsV1;
+import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
+import org.hyperledger.besu.ethereum.core.kzg.CKZG4844Helper;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.util.HexUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.vertx.core.Vertx;
+import jakarta.validation.constraints.NotNull;
+import org.apache.tuweni.bytes.Bytes;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of engine_getBlobsV4 API method.
+ *
+ * <p>Unlike {@code engine_getBlobsV3}, this method returns only the individual cells (and their KZG
+ * proofs) selected by a caller-supplied indices bitarray, rather than full blobs.
+ *
+ * <p>Specification:
+ *
+ * <ul>
+ *   <li>Returns partial responses with null entries for missing blobs
+ *   <li>Supports at least 128 blob versioned hashes per request
+ *   <li>Only supports KZG_CELL_PROOFS blob type (rejects KZG_PROOF)
+ *   <li>Each returned {@link BlobCellsAndProofsV1} contains only the cells/proofs at the indices
+ *       set in {@code indices_bitarray}
+ * </ul>
+ */
+public class EngineGetBlobsV4 extends ExecutionEngineJsonRpcMethod {
+  private static final Logger LOG = LoggerFactory.getLogger(EngineGetBlobsV4.class);
+  public static final int REQUEST_MAX_VERSIONED_HASHES = 128;
+  private static final int INDICES_BITARRAY_BYTE_LENGTH = 16;
+
+  private final TransactionPool transactionPool;
+  private final Counter requestedCounter;
+  private final Counter availableCounter;
+  private final Counter partialResponseCounter;
+  private final Counter fullResponseCounter;
+  private final Optional<Long> amsterdamMilestone;
+
+  public EngineGetBlobsV4(
+      final Vertx vertx,
+      final ProtocolContext protocolContext,
+      final ProtocolSchedule protocolSchedule,
+      final EngineCallListener engineCallListener,
+      final TransactionPool transactionPool,
+      final MetricsSystem metricsSystem) {
+    super(vertx, protocolSchedule, protocolContext, engineCallListener);
+    this.transactionPool = transactionPool;
+    this.requestedCounter =
+        metricsSystem.createCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_v4_requested_total",
+            "Number of blobs requested via engine_getBlobsV4");
+    this.availableCounter =
+        metricsSystem.createCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_v4_available_total",
+            "Number of blobs requested via engine_getBlobsV4 that are present in the blob pool");
+    this.partialResponseCounter =
+        metricsSystem.createCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_v4_partial_total",
+            "Number of calls to engine_getBlobsV4 that returned partial responses");
+    this.fullResponseCounter =
+        metricsSystem.createCounter(
+            BesuMetricCategory.RPC,
+            "execution_engine_getblobs_v4_full_total",
+            "Number of calls to engine_getBlobsV4 that returned complete responses");
+    this.amsterdamMilestone = protocolSchedule.milestoneFor(AMSTERDAM);
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.ENGINE_GET_BLOBS_V4.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
+    final VersionedHash[] versionedHashes = extractVersionedHashes(requestContext);
+    final Bytes indicesBitarray = extractIndicesBitarray(requestContext);
+    if (versionedHashes.length > REQUEST_MAX_VERSIONED_HASHES) {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(),
+          RpcErrorType.INVALID_ENGINE_GET_BLOBS_TOO_LARGE_REQUEST);
+    }
+    if (mergeContext.get().isSyncing()) {
+      return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), null);
+    }
+    long timestamp = protocolContext.getBlockchain().getChainHeadHeader().getTimestamp();
+    ValidationResult<RpcErrorType> forkValidationResult = validateForkSupported(timestamp);
+    if (!forkValidationResult.isValid()) {
+      return new JsonRpcErrorResponse(requestContext.getRequest().getId(), forkValidationResult);
+    }
+
+    requestedCounter.inc(versionedHashes.length);
+
+    final List<Integer> cellIndexes = cellIndexesFor(indicesBitarray);
+    final List<BlobCellsAndProofsV1> result = getBlobV4Result(versionedHashes, cellIndexes);
+
+    // count available blobs (non-null entries)
+    long availableCount = result.stream().mapToLong(blob -> blob != null ? 1 : 0).sum();
+    availableCounter.inc(availableCount);
+
+    // track if this was a partial or full response
+    if (availableCount == versionedHashes.length) {
+      fullResponseCounter.inc();
+    } else {
+      partialResponseCounter.inc();
+    }
+
+    LOG.debug(
+        "Requested {} bundles, found {} valid bundles ({} partial response)",
+        versionedHashes.length,
+        availableCount,
+        availableCount < versionedHashes.length);
+
+    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result);
+  }
+
+  private VersionedHash[] extractVersionedHashes(final JsonRpcRequestContext requestContext) {
+    try {
+      return requestContext.getRequiredParameter(0, VersionedHash[].class);
+    } catch (JsonRpcParameter.JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid versioned hashes parameter (index 0)",
+          RpcErrorType.INVALID_VERSIONED_HASHES_PARAMS,
+          e);
+    }
+  }
+
+  private Bytes extractIndicesBitarray(final JsonRpcRequestContext requestContext) {
+    final Bytes indicesBitarray;
+    try {
+      indicesBitarray = requestContext.getRequiredParameter(1, Bytes.class);
+    } catch (JsonRpcParameter.JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid indices bitarray parameter (index 1)",
+          RpcErrorType.INVALID_INDICES_BITARRAY_PARAMS,
+          e);
+    }
+    if (indicesBitarray.size() != INDICES_BITARRAY_BYTE_LENGTH) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid indices bitarray parameter (index 1): expected %d bytes, got %d"
+              .formatted(INDICES_BITARRAY_BYTE_LENGTH, indicesBitarray.size()),
+          RpcErrorType.INVALID_INDICES_BITARRAY_PARAMS);
+    }
+    return indicesBitarray;
+  }
+
+  private List<Integer> cellIndexesFor(final Bytes indicesBitarray) {
+    final List<Integer> indexes = new ArrayList<>();
+    for (int i = 0; i < CKZG4844Helper.CELL_PROOFS_PER_BLOB; i++) {
+      final int byteIndex = i / Byte.SIZE;
+      final int bitIndex = i % Byte.SIZE;
+      if ((Byte.toUnsignedInt(indicesBitarray.get(byteIndex)) & (1 << bitIndex)) != 0) {
+        indexes.add(i);
+      }
+    }
+    return indexes;
+  }
+
+  private @NotNull List<BlobCellsAndProofsV1> getBlobV4Result(
+      final VersionedHash[] versionedHashes, final List<Integer> cellIndexes) {
+    return Arrays.stream(versionedHashes)
+        .map(transactionPool::getBlobProofBundle)
+        .map(bundle -> getBlobCellsAndProofsV1(bundle, cellIndexes))
+        .toList();
+  }
+
+  private @Nullable BlobCellsAndProofsV1 getBlobCellsAndProofsV1(
+      final BlobProofBundle bundle, final List<Integer> cellIndexes) {
+    if (bundle == null) {
+      return null;
+    }
+    // Only KZG_CELL_PROOFS blobs support cell-level extraction, reject KZG_PROOF
+    if (bundle.getBlobType() == BlobType.KZG_PROOF) {
+      LOG.trace(
+          "Unsupported blob type KZG_PROOF for versioned hash: {}", bundle.getVersionedHash());
+      return null;
+    }
+    final Bytes blobCells = bundle.getBlobCellsBytes().orElse(null);
+    if (blobCells == null) {
+      return null;
+    }
+    final int cellSize = blobCells.size() / CKZG4844Helper.CELL_PROOFS_PER_BLOB;
+    final List<String> cells =
+        cellIndexes.stream()
+            .map(index -> blobCells.slice(index * cellSize, cellSize))
+            .map(cell -> HexUtils.toFastHex(cell, true))
+            .toList();
+    final List<String> proofs =
+        cellIndexes.stream()
+            .map(index -> bundle.getKzgProof().get(index))
+            .map(proof -> HexUtils.toFastHex(proof.getData(), true))
+            .toList();
+    return new BlobCellsAndProofsV1(cells, proofs);
+  }
+
+  @Override
+  protected ValidationResult<RpcErrorType> validateForkSupported(final long currentTimestamp) {
+    return ForkSupportHelper.validateForkSupported(AMSTERDAM, amsterdamMilestone, currentTimestamp);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/ForkchoiceUpdatedRequestParametersV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/ForkchoiceUpdatedRequestParametersV1.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
+
+import java.util.Optional;
+
+public sealed class ForkchoiceUpdatedRequestParametersV1<PA extends PayloadAttributesV1>
+    permits ForkchoiceUpdatedRequestParametersV2 {
+  private final ForkchoiceStateV1 forkchoiceState;
+  private final PA payloadAttributes;
+
+  public ForkchoiceUpdatedRequestParametersV1(
+      final ForkchoiceStateV1 forkchoiceState, final Optional<PA> payloadAttributes) {
+    this.forkchoiceState = forkchoiceState;
+    this.payloadAttributes = payloadAttributes.orElse(null);
+  }
+
+  public ForkchoiceUpdatedRequestParametersV1(
+      final ForkchoiceUpdatedRequestParametersV1<? extends PA> requestParameters) {
+    this.forkchoiceState = requestParameters.forkchoiceState();
+    this.payloadAttributes = requestParameters.payloadAttributes().orElse(null);
+  }
+
+  public ForkchoiceStateV1 forkchoiceState() {
+    return forkchoiceState;
+  }
+
+  public Optional<PA> payloadAttributes() {
+    return Optional.ofNullable(payloadAttributes);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/ForkchoiceUpdatedRequestParametersV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/ForkchoiceUpdatedRequestParametersV2.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
+
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public final class ForkchoiceUpdatedRequestParametersV2<PA extends PayloadAttributesV1>
+    extends ForkchoiceUpdatedRequestParametersV1<PA> {
+  private final Optional<Bytes> custodyColumns;
+
+  public ForkchoiceUpdatedRequestParametersV2(
+      final ForkchoiceUpdatedRequestParametersV1<? extends PA> requestParameters,
+      final Optional<Bytes> custodyColumns) {
+    super(requestParameters);
+    this.custodyColumns = custodyColumns;
+  }
+
+  public Optional<Bytes> custodyColumns() {
+    return custodyColumns;
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
@@ -44,6 +44,7 @@ public enum RpcErrorType implements RpcMethodError {
   INVALID_CALL_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid call params"),
   INVALID_CONSOLIDATION_REQUEST_PARAMS(
       INVALID_PARAMS_ERROR_CODE, "Invalid consolidation request params"),
+  INVALID_CUSTODY_COLUMNS_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid custody columns params"),
   INVALID_DATA_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid data params"),
   INVALID_DATA_HASH_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid data hash params"),
   INVALID_DEPOSIT_REQUEST_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid deposit request"),
@@ -69,6 +70,7 @@ public enum RpcErrorType implements RpcMethodError {
   INVALID_FILTER_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid filter params"),
   INVALID_HASH_RATE_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid hash rate params"),
   INVALID_ID_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid ID params"),
+  INVALID_INDICES_BITARRAY_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid indices bitarray params"),
   INVALID_RETURN_COMPLETE_TRANSACTION_PARAMS(
       INVALID_PARAMS_ERROR_CODE, "Invalid return complete transaction params"),
   INVALID_LOG_FILTER_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid log filter params"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobCellsAndProofsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobCellsAndProofsV1.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * The result of the engine_getBlobsV4 JSON-RPC method contains an array of BlobCellsAndProofsV1.
+ * BlobCellsAndProofsV1 contains the cells selected by the requested indices bitarray and their
+ * corresponding KZG proofs.
+ */
+@JsonPropertyOrder({"blob_cells", "proofs"})
+public class BlobCellsAndProofsV1 {
+
+  private final List<String> blobCells;
+
+  private final List<String> proofs;
+
+  public BlobCellsAndProofsV1(final List<String> blobCells, final List<String> proofs) {
+    this.blobCells = blobCells;
+    this.proofs = proofs;
+  }
+
+  @JsonProperty("blob_cells")
+  public List<String> getBlobCells() {
+    return blobCells;
+  }
+
+  public List<String> getProofs() {
+    return proofs;
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineF
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetBlobsV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetBlobsV2;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetBlobsV3;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetBlobsV4;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetClientVersionV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetPayloadBodiesByHashV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetPayloadBodiesByHashV2;
@@ -127,7 +128,8 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
               engineQosTimer,
               mergeCoordinator.get(),
               ethPeers,
-              metricsSystem);
+              metricsSystem,
+              transactionPool);
 
       List<JsonRpcMethod> executionEngineApisSupported = new ArrayList<>();
       executionEngineApisSupported.addAll(
@@ -232,6 +234,14 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
         executionEngineApisSupported.add(
             new EngineGetPayloadBodiesByRangeV2(
                 consensusEngineServer, protocolContext, blockResultFactory, engineQosTimer));
+        executionEngineApisSupported.add(
+            new EngineGetBlobsV4(
+                consensusEngineServer,
+                protocolContext,
+                protocolSchedule,
+                engineQosTimer,
+                transactionPool,
+                metricsSystem));
       }
 
       return mapOf(executionEngineApisSupported);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedBadAncestorIntegrationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedBadAncestorIntegrationTest.java
@@ -143,6 +143,7 @@ public class EngineForkchoiceUpdatedBadAncestorIntegrationTest {
                 .mergeCoordinator(mergeCoordinator)
                 .ethPeers(mock(EthPeers.class))
                 .metricsSystem(new NoOpMetricsSystem())
+                .transactionPool(transactionPool)
                 .build(),
             CANCUN,
             AMSTERDAM);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedBadAncestorIntegrationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedBadAncestorIntegrationTest.java
@@ -90,7 +90,7 @@ public class EngineForkchoiceUpdatedBadAncestorIntegrationTest {
   private BadBlockManager badBlockManager;
   private MutableBlockchain blockchain;
   private MergeCoordinator mergeCoordinator;
-  private EngineForkchoiceUpdatedV3<PayloadAttributesV3> method;
+  private EngineForkchoiceUpdatedV3<PayloadAttributesV3, ?> method;
 
   @BeforeEach
   public void setUp() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -51,6 +51,7 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
@@ -91,6 +92,7 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
   @Mock protected MergeMiningCoordinator mergeCoordinator;
   @Mock protected MutableBlockchain blockchain;
   @Mock protected EngineCallListener engineCallListener;
+  @Mock protected TransactionPool transactionPool;
 
   @Override
   @BeforeEach
@@ -114,6 +116,7 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(mock(EthPeers.class))
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         null,
         SHANGHAI);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -75,7 +75,7 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
   protected static final Consumer<BlockHeaderTestFixture> NO_OP = bhb -> {};
-  protected EngineForkchoiceUpdatedV1<?> method;
+  protected EngineForkchoiceUpdatedV1<?, ?> method;
 
   protected static final Vertx vertx = Vertx.vertx();
   protected static final Hash mockHash = Hash.hash(Bytes32.fromHexStringLenient("0x1337deadbeef"));
@@ -106,7 +106,7 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
   }
 
   /** Returns the method factory for the version under test. Overridden by each subclass. */
-  protected EngineForkchoiceUpdatedV1<?> createMethodInstance() {
+  protected EngineForkchoiceUpdatedV1<?, ?> createMethodInstance() {
     return new EngineForkchoiceUpdatedV1<>(
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -55,7 +55,7 @@ public class EngineForkchoiceUpdatedV2Test extends EngineForkchoiceUpdatedV1Test
   private final long withdrawalsEnabledTimestamp = shanghaiHardfork.milestone();
 
   @Override
-  protected EngineForkchoiceUpdatedV1<?> createMethodInstance() {
+  protected EngineForkchoiceUpdatedV1<?, ?> createMethodInstance() {
     return new EngineForkchoiceUpdatedV2<>(
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -65,6 +65,7 @@ public class EngineForkchoiceUpdatedV2Test extends EngineForkchoiceUpdatedV1Test
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(mock(EthPeers.class))
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         PARIS,
         CANCUN);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3Test.java
@@ -48,7 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class EngineForkchoiceUpdatedV3Test extends EngineForkchoiceUpdatedV2Test {
 
   @Override
-  protected EngineForkchoiceUpdatedV1<?> createMethodInstance() {
+  protected EngineForkchoiceUpdatedV1<?, ?> createMethodInstance() {
     return new EngineForkchoiceUpdatedV3<>(
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3Test.java
@@ -58,6 +58,7 @@ public class EngineForkchoiceUpdatedV3Test extends EngineForkchoiceUpdatedV2Test
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(mock(EthPeers.class))
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         CANCUN,
         AMSTERDAM);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
@@ -52,7 +52,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test {
 
   @Override
-  protected EngineForkchoiceUpdatedV1<?> createMethodInstance() {
+  protected EngineForkchoiceUpdatedV1<?, ?> createMethodInstance() {
     // V4 has no upper bound (null maxFork = open-ended).
     return new EngineForkchoiceUpdatedV4<>(
         new ConstructorArgumentsBuilder()

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
@@ -18,11 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.AMSTERDAM;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceStateV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttributesV4;
@@ -38,6 +41,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,9 +63,22 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(mock(EthPeers.class))
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         AMSTERDAM,
         null);
+  }
+
+  private JsonRpcResponse respWithCustodyColumns(
+      final ForkchoiceStateV1 forkchoiceParam,
+      final Optional<Object> payloadParam,
+      final Object custodyColumnsParam) {
+    return method.response(
+        new JsonRpcRequestContext(
+            new JsonRpcRequest(
+                "2.0",
+                getMethodName(),
+                new Object[] {forkchoiceParam, payloadParam.orElse(null), custodyColumnsParam})));
   }
 
   @Override
@@ -215,5 +232,52 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
         ArgumentCaptor.forClass(MergeMiningCoordinator.PreparePayloadArgs.class);
     verify(mergeCoordinator).preparePayload(captor.capture());
     assertThat(captor.getValue().targetGasLimit()).contains(targetGasLimitValue);
+  }
+
+  // ---- custodyColumns (EIP-8070 Engine API) tests ----
+
+  @Test
+  public void shouldPersistValidCustodyColumns() {
+    final BlockHeader mockHeader = setupValidForkchoiceUpdate();
+    final Bytes custodyColumns = Bytes.repeat((byte) 0xAB, 16);
+
+    final JsonRpcResponse resp =
+        respWithCustodyColumns(
+            new ForkchoiceStateV1(mockHeader.getBlockHash(), Hash.ZERO, Hash.ZERO),
+            Optional.empty(),
+            custodyColumns);
+
+    assertThat(resp).isInstanceOf(JsonRpcSuccessResponse.class);
+    verify(transactionPool).updateBlobCustodyColumns(custodyColumns);
+  }
+
+  @Test
+  public void shouldNotTouchTransactionPoolWhenCustodyColumnsOmitted() {
+    final BlockHeader mockHeader = setupValidForkchoiceUpdate();
+
+    final JsonRpcResponse resp =
+        resp(
+            new ForkchoiceStateV1(mockHeader.getBlockHash(), Hash.ZERO, Hash.ZERO),
+            Optional.empty());
+
+    assertThat(resp).isInstanceOf(JsonRpcSuccessResponse.class);
+    verifyNoInteractions(transactionPool);
+  }
+
+  @Test
+  public void shouldRejectWrongLengthCustodyColumnsBeforeTouchingForkchoice() {
+    final Bytes badCustodyColumns = Bytes.repeat((byte) 0xAB, 10);
+
+    final JsonRpcResponse resp =
+        respWithCustodyColumns(
+            new ForkchoiceStateV1(Hash.ZERO, Hash.ZERO, Hash.ZERO),
+            Optional.empty(),
+            badCustodyColumns);
+
+    assertThat(resp).isInstanceOf(JsonRpcErrorResponse.class);
+    assertThat(((JsonRpcErrorResponse) resp).getErrorType())
+        .isEqualTo(RpcErrorType.INVALID_CUSTODY_COLUMNS_PARAMS);
+    verifyNoInteractions(mergeCoordinator);
+    verifyNoInteractions(transactionPool);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV4Test.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.hyperledger.besu.datatypes.BlobType.KZG_CELL_PROOFS;
+import static org.hyperledger.besu.datatypes.BlobType.KZG_PROOF;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.VersionedHash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobCellsAndProofsV1;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.BlobTestFixture;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
+import org.hyperledger.besu.ethereum.core.kzg.CKZG4844Helper;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.metrics.ObservableMetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import io.vertx.core.Vertx;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith({MockitoExtension.class})
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class EngineGetBlobsV4Test extends AbstractScheduledApiTest {
+  private static final Bytes FULL_BITARRAY = Bytes.repeat((byte) 0xFF, 16);
+
+  @Mock private BlockHeader blockHeader;
+  @Mock private MutableBlockchain blockchain;
+
+  private TransactionPool transactionPool;
+  private EngineGetBlobsV4 method;
+
+  @Mock Counter requestedCounter;
+  @Mock Counter availableCounter;
+  @Mock Counter partialResponseCounter;
+  @Mock Counter fullResponseCounter;
+  @Mock ObservableMetricsSystem metricsSystem;
+  @Mock MergeContext mergeContext;
+
+  @BeforeEach
+  public void setup() {
+    transactionPool = mock(TransactionPool.class);
+    ProtocolContext protocolContext = mock(ProtocolContext.class);
+    when(mergeContext.isSyncing()).thenReturn(false);
+    when(protocolContext.safeConsensusContext(any())).thenReturn(Optional.ofNullable(mergeContext));
+    when(protocolContext.getBlockchain()).thenReturn(blockchain);
+    when(blockHeader.getTimestamp()).thenReturn(amsterdamHardfork.milestone());
+    when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
+
+    when(metricsSystem.createCounter(
+            eq(BesuMetricCategory.RPC),
+            eq("execution_engine_getblobs_v4_requested_total"),
+            anyString()))
+        .thenReturn(requestedCounter);
+    when(metricsSystem.createCounter(
+            eq(BesuMetricCategory.RPC),
+            eq("execution_engine_getblobs_v4_available_total"),
+            anyString()))
+        .thenReturn(availableCounter);
+    when(metricsSystem.createCounter(
+            eq(BesuMetricCategory.RPC),
+            eq("execution_engine_getblobs_v4_partial_total"),
+            anyString()))
+        .thenReturn(partialResponseCounter);
+    when(metricsSystem.createCounter(
+            eq(BesuMetricCategory.RPC), eq("execution_engine_getblobs_v4_full_total"), anyString()))
+        .thenReturn(fullResponseCounter);
+
+    method =
+        new EngineGetBlobsV4(
+            mock(Vertx.class),
+            protocolContext,
+            protocolSchedule,
+            mock(EngineCallListener.class),
+            transactionPool,
+            metricsSystem);
+  }
+
+  @Test
+  public void shouldReturnMethodName() {
+    assertThat(method.getName()).isEqualTo(RpcMethod.ENGINE_GET_BLOBS_V4.getMethodName());
+  }
+
+  @Test
+  public void shouldReturnAllCellsForFullBitarray() {
+    BlobProofBundle bundle = createBundleWithBlobType(KZG_CELL_PROOFS);
+    JsonRpcSuccessResponse response =
+        getSuccessResponse(buildRequestContext(FULL_BITARRAY, bundle.getVersionedHash()));
+
+    @SuppressWarnings("unchecked")
+    List<BlobCellsAndProofsV1> result = (List<BlobCellsAndProofsV1>) response.getResult();
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().getBlobCells()).hasSize(CKZG4844Helper.CELL_PROOFS_PER_BLOB);
+    assertThat(result.getFirst().getProofs()).hasSize(CKZG4844Helper.CELL_PROOFS_PER_BLOB);
+
+    verify(requestedCounter).inc(1);
+    verify(availableCounter).inc(1);
+    verify(fullResponseCounter).inc();
+    verifyNoInteractions(partialResponseCounter);
+  }
+
+  @Test
+  public void shouldReturnOnlySelectedCellsForPartialBitarray() {
+    BlobProofBundle bundle = createBundleWithBlobType(KZG_CELL_PROOFS);
+    // select cell index 0 and cell index 127 only
+    byte[] maskBytes = new byte[16];
+    maskBytes[0] = 0x01;
+    maskBytes[15] = (byte) 0x80;
+    Bytes bitarray = Bytes.wrap(maskBytes);
+
+    JsonRpcSuccessResponse response =
+        getSuccessResponse(buildRequestContext(bitarray, bundle.getVersionedHash()));
+
+    @SuppressWarnings("unchecked")
+    List<BlobCellsAndProofsV1> result = (List<BlobCellsAndProofsV1>) response.getResult();
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().getBlobCells()).hasSize(2);
+    assertThat(result.getFirst().getProofs()).hasSize(2);
+
+    Bytes blobCells = bundle.getBlobCellsBytes().orElseThrow();
+    int cellSize = blobCells.size() / CKZG4844Helper.CELL_PROOFS_PER_BLOB;
+    String expectedCell0 = blobCells.slice(0, cellSize).toHexString();
+    String expectedCell127 = blobCells.slice(127 * cellSize, cellSize).toHexString();
+    assertThat(result.getFirst().getBlobCells()).containsExactly(expectedCell0, expectedCell127);
+    assertThat(result.getFirst().getProofs())
+        .containsExactly(
+            bundle.getKzgProof().get(0).getData().toHexString(),
+            bundle.getKzgProof().get(127).getData().toHexString());
+  }
+
+  @Test
+  public void shouldReturnNullForMissingBlobsInPartialResponse() {
+    BlobProofBundle bundle1 = createBundleWithBlobType(KZG_CELL_PROOFS);
+    VersionedHash unknownHash = new VersionedHash((byte) 1, Hash.ZERO);
+    BlobProofBundle bundle3 = createBundleWithBlobType(KZG_CELL_PROOFS);
+
+    when(transactionPool.getBlobProofBundle(bundle1.getVersionedHash())).thenReturn(bundle1);
+    when(transactionPool.getBlobProofBundle(unknownHash)).thenReturn(null);
+    when(transactionPool.getBlobProofBundle(bundle3.getVersionedHash())).thenReturn(bundle3);
+
+    JsonRpcSuccessResponse response =
+        getSuccessResponse(
+            buildRequestContext(
+                FULL_BITARRAY,
+                bundle1.getVersionedHash(),
+                unknownHash,
+                bundle3.getVersionedHash()));
+
+    @SuppressWarnings("unchecked")
+    List<BlobCellsAndProofsV1> result = (List<BlobCellsAndProofsV1>) response.getResult();
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0)).isNotNull();
+    assertThat(result.get(1)).isNull();
+    assertThat(result.get(2)).isNotNull();
+
+    verify(requestedCounter).inc(3);
+    verify(availableCounter).inc(2);
+    verify(partialResponseCounter).inc();
+    verifyNoInteractions(fullResponseCounter);
+  }
+
+  @Test
+  public void shouldReturnNullForKzgProofBlobType() {
+    BlobProofBundle bundle = createBundleWithBlobType(KZG_PROOF);
+    JsonRpcSuccessResponse response =
+        getSuccessResponse(buildRequestContext(FULL_BITARRAY, bundle.getVersionedHash()));
+
+    @SuppressWarnings("unchecked")
+    List<BlobCellsAndProofsV1> result = (List<BlobCellsAndProofsV1>) response.getResult();
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst()).isNull();
+
+    verify(requestedCounter).inc(1);
+    verify(availableCounter).inc(0);
+    verify(partialResponseCounter).inc();
+    verifyNoInteractions(fullResponseCounter);
+  }
+
+  @Test
+  public void shouldReturnErrorForTooLargeRequest() {
+    VersionedHash[] tooManyHashes = new VersionedHash[129]; // > 128 limit
+    Arrays.fill(tooManyHashes, new VersionedHash((byte) 1, Hash.ZERO));
+
+    JsonRpcResponse response =
+        method.syncResponse(buildRequestContext(FULL_BITARRAY, tooManyHashes));
+
+    assertThat(fromErrorResp(response).getCode())
+        .isEqualTo(RpcErrorType.INVALID_ENGINE_GET_BLOBS_TOO_LARGE_REQUEST.getCode());
+  }
+
+  @Test
+  public void shouldRejectWrongLengthIndicesBitarray() {
+    VersionedHash hash = new VersionedHash((byte) 1, Hash.ZERO);
+    JsonRpcRequestContext context = buildRequestContext(Bytes.repeat((byte) 0xFF, 15), hash);
+
+    InvalidJsonRpcParameters exception =
+        catchThrowableOfType(() -> method.syncResponse(context), InvalidJsonRpcParameters.class);
+
+    assertThat(exception).isNotNull();
+    assertThat(exception.getRpcErrorType()).isEqualTo(RpcErrorType.INVALID_INDICES_BITARRAY_PARAMS);
+  }
+
+  @Test
+  public void shouldReturnNullWhenSyncing() {
+    when(mergeContext.isSyncing()).thenReturn(true);
+    BlobProofBundle bundle = createBundleWithBlobType(KZG_CELL_PROOFS);
+
+    JsonRpcSuccessResponse response =
+        getSuccessResponse(buildRequestContext(FULL_BITARRAY, bundle.getVersionedHash()));
+
+    assertThat(response.getResult()).isNull();
+    verifyNoInteractions(
+        requestedCounter, availableCounter, partialResponseCounter, fullResponseCounter);
+  }
+
+  @Test
+  public void shouldSupportMinimum128Hashes() {
+    VersionedHash[] maxHashes = new VersionedHash[128];
+    Arrays.fill(maxHashes, new VersionedHash((byte) 1, Hash.ZERO));
+
+    JsonRpcResponse response = method.syncResponse(buildRequestContext(FULL_BITARRAY, maxHashes));
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
+  }
+
+  private BlobProofBundle createBundleWithBlobType(
+      final org.hyperledger.besu.datatypes.BlobType blobType) {
+    BlobTestFixture blobTestFixture = new BlobTestFixture();
+    BlobProofBundle bundle = blobTestFixture.createBlobProofBundle(blobType);
+    when(transactionPool.getBlobProofBundle(bundle.getVersionedHash())).thenReturn(bundle);
+    return bundle;
+  }
+
+  private JsonRpcRequestContext buildRequestContext(
+      final Bytes indicesBitarray, final VersionedHash... hashes) {
+    return new JsonRpcRequestContext(
+        new JsonRpcRequest(
+            "2.0",
+            RpcMethod.ENGINE_GET_BLOBS_V4.getMethodName(),
+            new Object[] {hashes, indicesBitarray}));
+  }
+
+  private JsonRpcSuccessResponse getSuccessResponse(final JsonRpcRequestContext request) {
+    JsonRpcResponse response = method.syncResponse(request);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
+    return (JsonRpcSuccessResponse) response;
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
@@ -53,6 +53,7 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -106,6 +107,8 @@ public class EngineNewPayloadV1Test extends AbstractScheduledApiTest {
 
   @Mock protected EngineCallListener engineCallListener;
 
+  @Mock protected TransactionPool transactionPool;
+
   @BeforeEach
   @Override
   public void before() {
@@ -133,6 +136,7 @@ public class EngineNewPayloadV1Test extends AbstractScheduledApiTest {
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         null,
         SHANGHAI);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2Test.java
@@ -66,6 +66,7 @@ public class EngineNewPayloadV2Test extends EngineNewPayloadV1Test {
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         null,
         CANCUN);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
@@ -108,6 +108,7 @@ public class EngineNewPayloadV3Test extends EngineNewPayloadV2Test {
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         CANCUN,
         PRAGUE);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
@@ -93,6 +93,7 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         PRAGUE,
         AMSTERDAM);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
@@ -72,6 +72,7 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
+            .transactionPool(transactionPool)
             .build(),
         AMSTERDAM,
         BOGOTA);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/VersionSchedulerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/VersionSchedulerTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngin
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineCallListener;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.ExecutionEngineJsonRpcMethods.VersionScheduler;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
@@ -52,6 +53,7 @@ class VersionSchedulerTest {
           .mergeCoordinator(mock(MergeMiningCoordinator.class))
           .ethPeers(mock(EthPeers.class))
           .metricsSystem(new NoOpMetricsSystem())
+          .transactionPool(mock(TransactionPool.class))
           .build();
 
   private final RecordingFactory v1 = new RecordingFactory();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -124,6 +124,7 @@ public class TransactionPool implements BlockAddedObserver {
   private final ListMultimap<VersionedHash, BlobProofBundle> mapOfBlobsInTransactionPool =
       Multimaps.synchronizedListMultimap(
           Multimaps.newListMultimap(new HashMap<>(), () -> new ArrayList<>(1)));
+  private final AtomicReference<Bytes> blobCustodyColumns = new AtomicReference<>();
 
   public TransactionPool(
       final Supplier<PendingTransactions> pendingTransactionsSupplier,
@@ -732,6 +733,20 @@ public class TransactionPool implements BlockAddedObserver {
       // do nothing
     }
     return cacheForBlobsOfTransactionsAddedToABlock.get(vh);
+  }
+
+  /**
+   * The CL's current blob custody column set, as last reported via {@code
+   * engine_forkchoiceUpdatedV4}'s {@code custodyColumns} parameter.
+   *
+   * @return the 16-byte custody bitarray, or empty if the CL has never reported one.
+   */
+  public Optional<Bytes> getBlobCustodyColumns() {
+    return Optional.ofNullable(blobCustodyColumns.get());
+  }
+
+  public void updateBlobCustodyColumns(final Bytes custodyColumns) {
+    blobCustodyColumns.set(custodyColumns);
   }
 
   public boolean isEnabled() {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTest.java
@@ -64,6 +64,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
@@ -80,6 +81,16 @@ import org.mockito.junit.jupiter.MockitoSettings;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = LENIENT)
 public abstract class AbstractTransactionPoolTest extends AbstractTransactionPoolTestBase {
+
+  @Test
+  public void blobCustodyColumnsStartsEmptyAndRoundTripsAfterUpdate() {
+    assertThat(transactionPool.getBlobCustodyColumns()).isEmpty();
+
+    final Bytes custodyColumns = Bytes.repeat((byte) 0xAB, 16);
+    transactionPool.updateBlobCustodyColumns(custodyColumns);
+
+    assertThat(transactionPool.getBlobCustodyColumns()).contains(custodyColumns);
+  }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})


### PR DESCRIPTION
Implements only the Amsterdam Engine API portion of EIP-8070 (sparse
blobpool): engine_getBlobsV4 returns per-cell blob data and KZG proofs
selected by an indices bitarray, and engine_forkchoiceUpdatedV4 gains
an optional custodyColumns parameter that is validated and persisted
on TransactionPool for future consumption. The devp2p/eth-72 wire
protocol and provider/sampler blobpool behavior are deliberately out
of scope for this increment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
