### PR TITLE
Parallel engine api execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 - Recover from restart during flatDB heal sync step [#10883](https://github.com/besu-eth/besu/pull/10883)
 
 ### Additions and Improvements
-- Engine API methods now execute concurrently, with only `engine_forkchoiceUpdated` calls processed serially in arrival order as the Engine API spec mandates. Previously all engine calls were serialized on a single thread, so light requests like `engine_getBlobsV2` could queue behind a block import and exceed the consensus client's timeout.
+- Engine API methods now execute concurrently, with only `engine_forkchoiceUpdated` and `engine_newPayload` calls processed serially in arrival order (the former as the Engine API spec mandates; the latter to keep it consistent, since both affect canonical chain state). Previously all engine calls were serialized on a single thread, so light requests like `engine_getBlobsV2` could queue behind a block import and exceed the consensus client's timeout.
 - Align Kotlin runtime dependencies to 2.4.0 to support plugins compiled against the Kotlin 2.4 API. [#10983](https://github.com/besu-eth/besu/pull/10983)
 - Add `--checkpoint=<hash>:<number>:<totalDifficulty>` CLI option to anchor sync to a trusted checkpoint, overriding any checkpoint configured in the genesis file. The option is only used by snap sync and is ignored (with a warning) in FULL sync-mode.
 - Extract the Plugin API core module: the plugin lifecycle, service lookup and shared block/transaction data views now live in a new `besu-plugin-api-core` artifact, re-exported by `besu-plugin-api` so existing consumers are unaffected. Also adds a minimal `org.hyperledger.besu.plugin.CoreConfiguration` service exposing the node data path. [#10875](https://github.com/besu-eth/besu/pull/10875)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Recover from restart during flatDB heal sync step [#10883](https://github.com/besu-eth/besu/pull/10883)
 
 ### Additions and Improvements
+- Engine API methods now execute concurrently, with only `engine_forkchoiceUpdated` calls processed serially in arrival order as the Engine API spec mandates. Previously all engine calls were serialized on a single thread, so light requests like `engine_getBlobsV2` could queue behind a block import and exceed the consensus client's timeout.
 - Align Kotlin runtime dependencies to 2.4.0 to support plugins compiled against the Kotlin 2.4 API. [#10983](https://github.com/besu-eth/besu/pull/10983)
 - Add `--checkpoint=<hash>:<number>:<totalDifficulty>` CLI option to anchor sync to a trusted checkpoint, overriding any checkpoint configured in the genesis file. The option is only used by snap sync and is ignored (with a warning) in FULL sync-mode.
 - Extract the Plugin API core module: the plugin lifecycle, service lookup and shared block/transaction data views now live in a new `besu-plugin-api-core` artifact, re-exported by `besu-plugin-api` so existing consumers are unaffected. Also adds a minimal `org.hyperledger.besu.plugin.CoreConfiguration` service exposing the node data path. [#10875](https://github.com/besu-eth/besu/pull/10875)

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -148,7 +148,6 @@ import com.google.common.base.Strings;
 import graphql.GraphQL;
 import inet.ipaddr.IPAddress;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -1377,8 +1376,11 @@ public class RunnerBuilder {
       final RpcEndpointServiceImpl rpcEndpointServiceImpl,
       final TransactionSimulator transactionSimulator,
       final EthScheduler ethScheduler) {
-    // sync vertx for engine consensus API, to process requests in FIFO order;
-    final Vertx consensusEngineServer = Vertx.vertx(new VertxOptions().setWorkerPoolSize(1));
+    // vertx for the engine consensus API: engine methods execute concurrently on its worker
+    // pool, except engine_forkchoiceUpdated calls, which the Engine API spec requires to be
+    // processed in the order received — those run on a dedicated single-threaded executor
+    // (see ExecutionEngineJsonRpcMethod#requiresOrderedExecution)
+    final Vertx consensusEngineServer = Vertx.vertx();
 
     final Map<String, JsonRpcMethod> methods =
         new JsonRpcMethodsFactory()

--- a/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/app/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -1377,9 +1377,9 @@ public class RunnerBuilder {
       final TransactionSimulator transactionSimulator,
       final EthScheduler ethScheduler) {
     // vertx for the engine consensus API: engine methods execute concurrently on its worker
-    // pool, except engine_forkchoiceUpdated calls, which the Engine API spec requires to be
-    // processed in the order received — those run on a dedicated single-threaded executor
-    // (see ExecutionEngineJsonRpcMethod#requiresOrderedExecution)
+    // pool, except engine_forkchoiceUpdated and engine_newPayload calls, which the Engine API
+    // spec requires to be processed in the order received — those run on a dedicated
+    // single-threaded executor (see OrderedExecutionJsonRpcMethod)
     final Vertx consensusEngineServer = Vertx.vertx();
 
     final Map<String, JsonRpcMethod> methods =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -30,18 +30,10 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.WorkerExecutor;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,15 +64,11 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionEngineJsonRpcMethod.class);
   public static final long ENGINE_API_LOGGING_THRESHOLD = 60000L;
-  // Must be <= the engine HTTP timeout so Thread A is released before the HTTP timer writes a
-  // response. Uses the same default (30s) as JsonRpcConfiguration.DEFAULT_HTTP_TIMEOUT_SEC.
-  private static final long ENGINE_API_RESPONSE_TIMEOUT_MS = 30_000L;
-  // Single-threaded executor shared by all methods requiring ordered execution, so that their
-  // calls are processed serially in arrival order regardless of which HTTP connection they
-  // arrive on.
-  private static final String ORDERED_EXECUTOR_NAME = "engine-ordered-execution";
-  private final Vertx syncVertx;
-  private final WorkerExecutor orderedExecutor;
+  // Shared engine consensus API Vertx instance. Only read by OrderedExecutionJsonRpcMethod
+  // (engine_forkchoiceUpdated / engine_newPayload), which uses it to run calls on a dedicated
+  // single-threaded executor rather than spinning up a Vertx instance just for ordering; every
+  // other engine method computes its response directly on the calling thread.
+  protected final Vertx syncVertx;
   protected final Optional<MergeContext> mergeContextOptional;
   protected final Supplier<MergeContext> mergeContext;
   protected final ProtocolSchedule protocolSchedule;
@@ -118,14 +106,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   }
 
   protected ExecutionEngineJsonRpcMethod(
-      final ProtocolSchedule protocolSchedule,
-      final ProtocolContext protocolContext,
-      final Vertx vertx,
-      final EngineCallListener engineCallListener) {
-    this(protocolSchedule, protocolContext, vertx, engineCallListener, null, null);
-  }
-
-  protected ExecutionEngineJsonRpcMethod(
       final ConstructorArguments constructorArguments,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
@@ -146,9 +126,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
     this.syncVertx = vertx;
-    // every instance gets its own wrapper, but all of them share the same named
-    // single-threaded pool
-    this.orderedExecutor = vertx.createSharedWorkerExecutor(ORDERED_EXECUTOR_NAME, 1);
     this.protocolSchedule = protocolSchedule;
     this.maybeProtocolSchedule = Optional.ofNullable(protocolSchedule);
     this.protocolContext = protocolContext;
@@ -168,82 +145,45 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   }
 
   @Override
-  public final JsonRpcResponse response(final JsonRpcRequestContext request) {
-
-    final CompletableFuture<JsonRpcResponse> cf = new CompletableFuture<>();
-
-    final Handler<Promise<JsonRpcResponse>> blockingHandler =
-        z -> {
-          logger()
-              .trace(
-                  "execution engine JSON-RPC request {} {}",
-                  this.getName(),
-                  request.getRequest().getParams());
-          z.tryComplete(syncResponse(request));
-        };
-    final Handler<AsyncResult<JsonRpcResponse>> resultHandler =
-        resp ->
-            cf.complete(
-                resp.otherwise(
-                        t -> {
-                          if (logger().isDebugEnabled()) {
-                            logger()
-                                .atDebug()
-                                .setMessage("failed to exec consensus method {}")
-                                .addArgument(this.getName())
-                                .setCause(t)
-                                .log();
-                          } else {
-                            logger()
-                                .atError()
-                                .setMessage("failed to exec consensus method {}, error: {}")
-                                .addArgument(this.getName())
-                                .addArgument(t.getMessage())
-                                .log();
-                          }
-                          return new JsonRpcErrorResponse(
-                              request.getRequest().getId(), RpcErrorType.INVALID_REQUEST);
-                        })
-                    .result());
-
-    if (requiresOrderedExecution()) {
-      // ordered=false: the executor's single thread already serializes execution, and unordered
-      // submission preserves global arrival order across HTTP connections, while ordered=true
-      // would only preserve it per calling context.
-      orderedExecutor.executeBlocking(blockingHandler, false, resultHandler);
-    } else {
-      syncVertx.executeBlocking(blockingHandler, false, resultHandler);
-    }
-    try {
-      return cf.get(ENGINE_API_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-    } catch (TimeoutException e) {
-      logger()
-          .debug(
-              "Timeout waiting for engine API response for {}, releasing worker thread",
-              this.getName());
-      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.TIMEOUT_ERROR);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      logger().error("Failed to get execution engine response", e);
-      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.TIMEOUT_ERROR);
-    } catch (ExecutionException e) {
-      logger().error("Failed to get execution engine response", e);
-      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.INTERNAL_ERROR);
-    }
+  public JsonRpcResponse response(final JsonRpcRequestContext request) {
+    return computeResponseSafely(request);
   }
 
   /**
-   * Whether calls to this method must be processed serially, in the same order as they have been
-   * received.
+   * Runs {@link #syncResponse}, converting any {@link Throwable} it throws into a {@link
+   * JsonRpcErrorResponse} instead of letting it propagate.
    *
-   * <p>The Engine API specification mandates this only for {@code engine_forkchoiceUpdated}
-   * ("Execution Layer client software MUST process engine_forkchoiceUpdated method calls in the
-   * same order as they have been received"), so by default engine methods execute concurrently on
-   * the engine Vertx worker pool and only the {@code engine_forkchoiceUpdated} hierarchy overrides
-   * this to return {@code true}.
+   * <p>{@link #response} calls this directly; {@link OrderedExecutionJsonRpcMethod} overrides
+   * {@link #response} to instead run this on a dedicated single-threaded executor, for methods the
+   * Engine API spec requires to be processed serially in arrival order (e.g. {@code
+   * engine_forkchoiceUpdated}, {@code engine_newPayload}).
    */
-  protected boolean requiresOrderedExecution() {
-    return false;
+  protected final JsonRpcResponse computeResponseSafely(final JsonRpcRequestContext request) {
+    logger()
+        .trace(
+            "execution engine JSON-RPC request {} {}",
+            this.getName(),
+            request.getRequest().getParams());
+    try {
+      return syncResponse(request);
+    } catch (final Throwable t) {
+      if (logger().isDebugEnabled()) {
+        logger()
+            .atDebug()
+            .setMessage("failed to exec consensus method {}")
+            .addArgument(this.getName())
+            .setCause(t)
+            .log();
+      } else {
+        logger()
+            .atError()
+            .setMessage("failed to exec consensus method {}, error: {}")
+            .addArgument(this.getName())
+            .addArgument(t.getMessage())
+            .log();
+      }
+      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.INVALID_REQUEST);
+    }
   }
 
   /**

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -37,7 +37,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +75,12 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   // Must be <= the engine HTTP timeout so Thread A is released before the HTTP timer writes a
   // response. Uses the same default (30s) as JsonRpcConfiguration.DEFAULT_HTTP_TIMEOUT_SEC.
   private static final long ENGINE_API_RESPONSE_TIMEOUT_MS = 30_000L;
+  // Single-threaded executor shared by all methods requiring ordered execution, so that their
+  // calls are processed serially in arrival order regardless of which HTTP connection they
+  // arrive on.
+  private static final String ORDERED_EXECUTOR_NAME = "engine-ordered-execution";
   private final Vertx syncVertx;
+  private final WorkerExecutor orderedExecutor;
   protected final Optional<MergeContext> mergeContextOptional;
   protected final Supplier<MergeContext> mergeContext;
   protected final ProtocolSchedule protocolSchedule;
@@ -137,6 +146,9 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
     this.syncVertx = vertx;
+    // every instance gets its own wrapper, but all of them share the same named
+    // single-threaded pool
+    this.orderedExecutor = vertx.createSharedWorkerExecutor(ORDERED_EXECUTOR_NAME, 1);
     this.protocolSchedule = protocolSchedule;
     this.maybeProtocolSchedule = Optional.ofNullable(protocolSchedule);
     this.protocolContext = protocolContext;
@@ -160,7 +172,7 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
 
     final CompletableFuture<JsonRpcResponse> cf = new CompletableFuture<>();
 
-    syncVertx.<JsonRpcResponse>executeBlocking(
+    final Handler<Promise<JsonRpcResponse>> blockingHandler =
         z -> {
           logger()
               .trace(
@@ -168,8 +180,8 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
                   this.getName(),
                   request.getRequest().getParams());
           z.tryComplete(syncResponse(request));
-        },
-        true,
+        };
+    final Handler<AsyncResult<JsonRpcResponse>> resultHandler =
         resp ->
             cf.complete(
                 resp.otherwise(
@@ -192,7 +204,16 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
                           return new JsonRpcErrorResponse(
                               request.getRequest().getId(), RpcErrorType.INVALID_REQUEST);
                         })
-                    .result()));
+                    .result());
+
+    if (requiresOrderedExecution()) {
+      // ordered=false: the executor's single thread already serializes execution, and unordered
+      // submission preserves global arrival order across HTTP connections, while ordered=true
+      // would only preserve it per calling context.
+      orderedExecutor.executeBlocking(blockingHandler, false, resultHandler);
+    } else {
+      syncVertx.executeBlocking(blockingHandler, false, resultHandler);
+    }
     try {
       return cf.get(ENGINE_API_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
@@ -209,6 +230,20 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       logger().error("Failed to get execution engine response", e);
       return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.INTERNAL_ERROR);
     }
+  }
+
+  /**
+   * Whether calls to this method must be processed serially, in the same order as they have been
+   * received.
+   *
+   * <p>The Engine API specification mandates this only for {@code engine_forkchoiceUpdated}
+   * ("Execution Layer client software MUST process engine_forkchoiceUpdated method calls in the
+   * same order as they have been received"), so by default engine methods execute concurrently on
+   * the engine Vertx worker pool and only the {@code engine_forkchoiceUpdated} hierarchy overrides
+   * this to return {@code true}.
+   */
+  protected boolean requiresOrderedExecution() {
+    return false;
   }
 
   /**

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -55,7 +55,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   public record ConstructorArguments(
       ProtocolSchedule protocolSchedule,
       ProtocolContext protocolContext,
-      Vertx vertx,
       EngineCallListener engineCallListener,
       MergeMiningCoordinator mergeCoordinator,
       EthPeers ethPeers,
@@ -64,11 +63,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionEngineJsonRpcMethod.class);
   public static final long ENGINE_API_LOGGING_THRESHOLD = 60000L;
-  // Shared engine consensus API Vertx instance. Only read by OrderedExecutionJsonRpcMethod
-  // (engine_forkchoiceUpdated / engine_newPayload), which uses it to run calls on a dedicated
-  // single-threaded executor rather than spinning up a Vertx instance just for ordering; every
-  // other engine method computes its response directly on the calling thread.
-  protected final Vertx syncVertx;
   protected final Optional<MergeContext> mergeContextOptional;
   protected final Supplier<MergeContext> mergeContext;
   protected final ProtocolSchedule protocolSchedule;
@@ -87,13 +81,16 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   private final HardforkId firstUnsupportedFork;
 
   // TRANSITIONAL SHIM (remove in cleanup PR): old constructor signature used by not-yet-migrated
-  // engine methods (vertx-first, optional protocol schedule).
+  // engine methods (vertx-first, optional protocol schedule). The Vertx parameter is unused here —
+  // kept only so these methods' constructors (and their call sites/tests) don't need touching;
+  // only OrderedExecutionJsonRpcMethod (engine_forkchoiceUpdated / engine_newPayload) actually
+  // needs a Vertx instance.
   protected ExecutionEngineJsonRpcMethod(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
       final EngineCallListener engineCallListener) {
-    this(protocolSchedule, protocolContext, vertx, engineCallListener, null, null);
+    this(protocolSchedule, protocolContext, engineCallListener, null, null);
   }
 
   // TRANSITIONAL SHIM (remove in cleanup PR): old constructor signature for methods that have no
@@ -102,7 +99,7 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       final Vertx vertx,
       final ProtocolContext protocolContext,
       final EngineCallListener engineCallListener) {
-    this(null, protocolContext, vertx, engineCallListener, null, null);
+    this(null, protocolContext, engineCallListener, null, null);
   }
 
   protected ExecutionEngineJsonRpcMethod(
@@ -112,7 +109,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
     this(
         constructorArguments.protocolSchedule(),
         constructorArguments.protocolContext(),
-        constructorArguments.vertx(),
         constructorArguments.engineCallListener(),
         minSupportedFork,
         firstUnsupportedFork);
@@ -121,11 +117,9 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   protected ExecutionEngineJsonRpcMethod(
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
-      final Vertx vertx,
       final EngineCallListener engineCallListener,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
-    this.syncVertx = vertx;
     this.protocolSchedule = protocolSchedule;
     this.maybeProtocolSchedule = Optional.ofNullable(protocolSchedule);
     this.protocolContext = protocolContext;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -33,8 +34,8 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
-import io.vertx.core.Vertx;
 import org.immutables.value.Value;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,30 +48,28 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
     INVALID_BLOCK_HASH;
   }
 
-  // Fields used by migrated series (currently engine_forkchoiceUpdatedV*, engine_newPayloadV*,
-  // engine_getPayloadV* and engine_getPayloadBodiesBy*
-  // — see the package README's migration status table). Not-yet-migrated series keep using the
-  // TRANSITIONAL SHIM constructors below instead of this record.
+  // Fields shared by every engine method series — see the package README's migration status
+  // table. Fields only some series read (e.g. mergeCoordinator is absent pre-merge,
+  // clientVersion/commit/transactionPool are read by a handful of series) are @Nullable rather
+  // than forcing every series/test to supply a value it doesn't use.
   @Value.Builder
   public record ConstructorArguments(
       ProtocolSchedule protocolSchedule,
       ProtocolContext protocolContext,
       EngineCallListener engineCallListener,
-      MergeMiningCoordinator mergeCoordinator,
+      @Nullable MergeMiningCoordinator mergeCoordinator,
       EthPeers ethPeers,
       MetricsSystem metricsSystem,
-      int maxRequestBlocks) {}
+      int maxRequestBlocks,
+      @Nullable String clientVersion,
+      @Nullable String commit,
+      @Nullable TransactionPool transactionPool) {}
 
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionEngineJsonRpcMethod.class);
   public static final long ENGINE_API_LOGGING_THRESHOLD = 60000L;
   protected final Optional<MergeContext> mergeContextOptional;
   protected final Supplier<MergeContext> mergeContext;
   protected final ProtocolSchedule protocolSchedule;
-
-  // TRANSITIONAL SHIM (remove in cleanup PR): not-yet-migrated engine methods reference the
-  // protocol schedule as an Optional under this name; new methods use the non-optional field above.
-  protected final Optional<ProtocolSchedule> maybeProtocolSchedule;
-
   protected final ProtocolContext protocolContext;
   protected final EngineCallListener engineCallListener;
 
@@ -79,28 +78,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
 
   private final HardforkId minSupportedFork;
   private final HardforkId firstUnsupportedFork;
-
-  // TRANSITIONAL SHIM (remove in cleanup PR): old constructor signature used by not-yet-migrated
-  // engine methods (vertx-first, optional protocol schedule). The Vertx parameter is unused here —
-  // kept only so these methods' constructors (and their call sites/tests) don't need touching;
-  // only OrderedExecutionJsonRpcMethod (engine_forkchoiceUpdated / engine_newPayload) actually
-  // needs a Vertx instance.
-  protected ExecutionEngineJsonRpcMethod(
-      final Vertx vertx,
-      final ProtocolSchedule protocolSchedule,
-      final ProtocolContext protocolContext,
-      final EngineCallListener engineCallListener) {
-    this(protocolSchedule, protocolContext, engineCallListener, null, null);
-  }
-
-  // TRANSITIONAL SHIM (remove in cleanup PR): old constructor signature for methods that have no
-  // protocol schedule.
-  protected ExecutionEngineJsonRpcMethod(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final EngineCallListener engineCallListener) {
-    this(null, protocolContext, engineCallListener, null, null);
-  }
 
   protected ExecutionEngineJsonRpcMethod(
       final ConstructorArguments constructorArguments,
@@ -121,7 +98,6 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
     this.protocolSchedule = protocolSchedule;
-    this.maybeProtocolSchedule = Optional.ofNullable(protocolSchedule);
     this.protocolContext = protocolContext;
     this.mergeContextOptional = protocolContext.safeConsensusContext(MergeContext.class);
     this.mergeContext = mergeContextOptional::orElseThrow;
@@ -206,9 +182,7 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
     return engineCallListener;
   }
 
-  // TRANSITIONAL: not 'final' yet (restored in cleanup PR) so not-yet-migrated engine methods can
-  // still override it; new methods inherit this implementation.
-  protected ValidationResult<RpcErrorType> validateForkSupported(final long blockTimestamp) {
+  protected final ValidationResult<RpcErrorType> validateForkSupported(final long blockTimestamp) {
     return ForkSupportHelper.validateForkSupported(
         minSupportedFork, minForkTimestamp, firstUnsupportedFork, maxForkTimestamp, blockTimestamp);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.datatypes.HardforkId;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.vertx.core.WorkerExecutor;
+
+/**
+ * Base class for engine methods the Engine API spec requires to be processed serially, in the same
+ * order as they were received (currently the {@code engine_forkchoiceUpdated} and {@code
+ * engine_newPayload} series — see the respective V1 classes).
+ *
+ * <p>All instances share one single-threaded {@link WorkerExecutor} created from the engine
+ * consensus API's existing Vertx instance (the same one backing {@code EngineQosTimer}), so calls
+ * are serialized globally in arrival order regardless of which HTTP connection they arrive on,
+ * without spinning up a dedicated Vertx instance just for ordering.
+ */
+public abstract class OrderedExecutionJsonRpcMethod extends ExecutionEngineJsonRpcMethod {
+
+  // Must be <= the engine HTTP timeout so Thread A is released before the HTTP timer writes a
+  // response. Uses the same default (30s) as JsonRpcConfiguration.DEFAULT_HTTP_TIMEOUT_SEC.
+  private static final long ENGINE_API_RESPONSE_TIMEOUT_MS = 30_000L;
+  private static final String ORDERED_EXECUTOR_NAME = "engine-ordered-execution";
+
+  // every instance gets its own wrapper, but all of them share the same named single-threaded pool
+  private final WorkerExecutor orderedExecutor;
+
+  protected OrderedExecutionJsonRpcMethod(
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    this.orderedExecutor = syncVertx.createSharedWorkerExecutor(ORDERED_EXECUTOR_NAME, 1);
+  }
+
+  @Override
+  public final JsonRpcResponse response(final JsonRpcRequestContext request) {
+    final CompletableFuture<JsonRpcResponse> cf = new CompletableFuture<>();
+
+    // ordered=false: the executor's single thread already serializes execution, and unordered
+    // submission preserves global arrival order across HTTP connections, while ordered=true
+    // would only preserve it per calling context.
+    orderedExecutor.<JsonRpcResponse>executeBlocking(
+        promise -> promise.complete(computeResponseSafely(request)),
+        false,
+        result -> cf.complete(result.result()));
+
+    try {
+      return cf.get(ENGINE_API_RESPONSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    } catch (final TimeoutException e) {
+      logger()
+          .debug(
+              "Timeout waiting for engine API response for {}, releasing worker thread",
+              this.getName());
+      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.TIMEOUT_ERROR);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger().error("Failed to get execution engine response", e);
+      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.TIMEOUT_ERROR);
+    } catch (final ExecutionException e) {
+      logger().error("Failed to get execution engine response", e);
+      return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.INTERNAL_ERROR);
+    }
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/OrderedExecutionJsonRpcMethod.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
 
 /**
@@ -35,7 +36,9 @@ import io.vertx.core.WorkerExecutor;
  * <p>All instances share one single-threaded {@link WorkerExecutor} created from the engine
  * consensus API's existing Vertx instance (the same one backing {@code EngineQosTimer}), so calls
  * are serialized globally in arrival order regardless of which HTTP connection they arrive on,
- * without spinning up a dedicated Vertx instance just for ordering.
+ * without spinning up a dedicated Vertx instance just for ordering. That Vertx instance is passed
+ * directly to this constructor rather than threaded through {@link ConstructorArguments}, since
+ * these are the only engine methods that need it.
  */
 public abstract class OrderedExecutionJsonRpcMethod extends ExecutionEngineJsonRpcMethod {
 
@@ -49,10 +52,11 @@ public abstract class OrderedExecutionJsonRpcMethod extends ExecutionEngineJsonR
 
   protected OrderedExecutionJsonRpcMethod(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
     super(constructorArguments, minSupportedFork, firstUnsupportedFork);
-    this.orderedExecutor = syncVertx.createSharedWorkerExecutor(ORDERED_EXECUTOR_NAME, 1);
+    this.orderedExecutor = vertx.createSharedWorkerExecutor(ORDERED_EXECUTOR_NAME, 1);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilities.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilities.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.ENGINE_EXCHANGE_CAPABILITIES;
 
-import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,10 +37,10 @@ public class EngineExchangeCapabilities extends ExecutionEngineJsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(EngineExchangeCapabilities.class);
 
   public EngineExchangeCapabilities(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final EngineCallListener engineCallListener) {
-    super(vertx, protocolContext, engineCallListener);
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -17,8 +17,8 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.ENGINE_EXCHANGE_TRANSITION_CONFIGURATION;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
@@ -37,7 +37,6 @@ import java.util.function.Supplier;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Suppliers;
-import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,10 +52,10 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
   private static final Supplier<ObjectMapper> mapperSupplier = Suppliers.memoize(ObjectMapper::new);
 
   public EngineExchangeTransitionConfiguration(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final EngineCallListener engineCallListener) {
-    super(vertx, protocolContext, engineCallListener);
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -28,7 +28,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.OrderedExecutionJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ForkchoiceStateV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.PayloadAttributesV1;
@@ -55,10 +55,14 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Parameterized so that V2 can extend this class while narrowing the payload type.
  *
+ * <p>Extends {@link OrderedExecutionJsonRpcMethod} because the Engine API spec mandates that
+ * forkchoiceUpdated calls are processed in the order they have been received; this applies to the
+ * whole sealed V1-V4 hierarchy.
+ *
  * @param <PA> the payload-attributes type this version accepts
  */
 public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
-    extends ExecutionEngineJsonRpcMethod permits EngineForkchoiceUpdatedV2 {
+    extends OrderedExecutionJsonRpcMethod permits EngineForkchoiceUpdatedV2 {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV1.class);
 
@@ -80,13 +84,6 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
   @Override
   public String getName() {
     return RpcMethod.ENGINE_FORKCHOICE_UPDATED_V1.getMethodName();
-  }
-
-  // The Engine API spec mandates that forkchoiceUpdated calls are processed in the order they
-  // have been received; applies to the whole sealed V1-V4 hierarchy.
-  @Override
-  protected final boolean requiresOrderedExecution() {
-    return true;
   }
 
   @SuppressWarnings("unchecked")

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -82,6 +82,13 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
     return RpcMethod.ENGINE_FORKCHOICE_UPDATED_V1.getMethodName();
   }
 
+  // The Engine API spec mandates that forkchoiceUpdated calls are processed in the order they
+  // have been received; applies to the whole sealed V1-V4 hierarchy.
+  @Override
+  protected final boolean requiresOrderedExecution() {
+    return true;
+  }
+
   @SuppressWarnings("unchecked")
   protected Class<PA> getPayloadAttributesClass() {
     return (Class<PA>) PayloadAttributesV1.class;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -43,6 +43,7 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,9 +76,10 @@ public sealed class EngineForkchoiceUpdatedV1<PA extends PayloadAttributesV1>
 
   public EngineForkchoiceUpdatedV1(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
-    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    super(constructorArguments, vertx, minSupportedFork, firstUnsupportedFork);
     this.mergeCoordinator = constructorArguments.mergeCoordinator();
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
 import java.util.Optional;
 
+import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,9 +46,10 @@ public sealed class EngineForkchoiceUpdatedV2<PA extends PayloadAttributesV2>
 
   public EngineForkchoiceUpdatedV2(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minFork,
       final HardforkId maxFork) {
-    super(constructorArguments, minFork, maxFork);
+    super(constructorArguments, vertx, minFork, maxFork);
     shanghaiTimestamp = protocolSchedule.milestoneFor(HardforkId.MainnetHardforkId.SHANGHAI);
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
+import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,9 +41,10 @@ public sealed class EngineForkchoiceUpdatedV3<PA extends PayloadAttributesV3>
 
   public EngineForkchoiceUpdatedV3(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minFork,
       final HardforkId maxFork) {
-    super(constructorArguments, minFork, maxFork);
+    super(constructorArguments, vertx, minFork, maxFork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
+import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,9 +56,10 @@ public final class EngineForkchoiceUpdatedV4<PA extends PayloadAttributesV4>
 
   public EngineForkchoiceUpdatedV4(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minFork,
       final HardforkId maxFork) {
-    super(constructorArguments, minFork, maxFork);
+    super(constructorArguments, vertx, minFork, maxFork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1.java
@@ -14,12 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
-
 import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.VersionedHash;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -32,15 +29,12 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV1;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import jakarta.validation.constraints.NotNull;
 import org.jspecify.annotations.Nullable;
 
@@ -69,19 +63,13 @@ import org.jspecify.annotations.Nullable;
 public class EngineGetBlobsV1 extends ExecutionEngineJsonRpcMethod {
 
   private final TransactionPool transactionPool;
-  private final Optional<Long> cancunMilestone;
-  private final Optional<Long> osakaMilestone;
 
   public EngineGetBlobsV1(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final ProtocolSchedule protocolSchedule,
-      final EngineCallListener engineCallListener,
-      final TransactionPool transactionPool) {
-    super(vertx, protocolContext, engineCallListener);
-    this.transactionPool = transactionPool;
-    this.cancunMilestone = protocolSchedule.milestoneFor(CANCUN);
-    this.osakaMilestone = protocolSchedule.milestoneFor(OSAKA);
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    this.transactionPool = constructorArguments.transactionPool();
   }
 
   @Override
@@ -137,11 +125,5 @@ public class EngineGetBlobsV1 extends ExecutionEngineJsonRpcMethod {
     }
     return new BlobAndProofV1(
         bq.getBlob().getData().toHexString(), bq.getKzgProof().getFirst().getData().toHexString());
-  }
-
-  @Override
-  protected ValidationResult<RpcErrorType> validateForkSupported(final long currentTimestamp) {
-    return ForkSupportHelper.validateForkSupported(
-        CANCUN, cancunMilestone, OSAKA, osakaMilestone, currentTimestamp);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2.java
@@ -14,11 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
-
 import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.VersionedHash;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -31,7 +29,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV2;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -40,9 +37,7 @@ import org.hyperledger.besu.util.HexUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,17 +50,14 @@ public class EngineGetBlobsV2 extends ExecutionEngineJsonRpcMethod {
   private final Counter availableCounter;
   private final Counter hitCounter;
   private final Counter missCounter;
-  private final Optional<Long> osakaMilestone;
 
   public EngineGetBlobsV2(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final ProtocolSchedule protocolSchedule,
-      final EngineCallListener engineCallListener,
-      final TransactionPool transactionPool,
-      final MetricsSystem metricsSystem) {
-    super(vertx, protocolSchedule, protocolContext, engineCallListener);
-    this.transactionPool = transactionPool;
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    this.transactionPool = constructorArguments.transactionPool();
+    final MetricsSystem metricsSystem = constructorArguments.metricsSystem();
     // create counters
     this.requestedCounter =
         metricsSystem.createCounter(
@@ -87,7 +79,6 @@ public class EngineGetBlobsV2 extends ExecutionEngineJsonRpcMethod {
             BesuMetricCategory.RPC,
             "execution_engine_getblobs_miss_total",
             "Number of calls to engine_getBlobsV2 that returned zero blobs");
-    this.osakaMilestone = protocolSchedule.milestoneFor(OSAKA);
   }
 
   @Override
@@ -169,10 +160,5 @@ public class EngineGetBlobsV2 extends ExecutionEngineJsonRpcMethod {
         blobProofBundle.getKzgProof().parallelStream()
             .map(proof -> HexUtils.toFastHex(proof.getData(), true))
             .toList());
-  }
-
-  @Override
-  protected ValidationResult<RpcErrorType> validateForkSupported(final long currentTimestamp) {
-    return ForkSupportHelper.validateForkSupported(OSAKA, osakaMilestone, currentTimestamp);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3.java
@@ -14,11 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
-
 import org.hyperledger.besu.datatypes.BlobType;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.datatypes.VersionedHash;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -31,7 +29,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlobAndProofV2;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -40,9 +37,7 @@ import org.hyperledger.besu.util.HexUtils;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import jakarta.validation.constraints.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -73,17 +68,14 @@ public class EngineGetBlobsV3 extends ExecutionEngineJsonRpcMethod {
   private final Counter availableCounter;
   private final Counter partialResponseCounter;
   private final Counter fullResponseCounter;
-  private final Optional<Long> osakaMilestone;
 
   public EngineGetBlobsV3(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final ProtocolSchedule protocolSchedule,
-      final EngineCallListener engineCallListener,
-      final TransactionPool transactionPool,
-      final MetricsSystem metricsSystem) {
-    super(vertx, protocolSchedule, protocolContext, engineCallListener);
-    this.transactionPool = transactionPool;
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    this.transactionPool = constructorArguments.transactionPool();
+    final MetricsSystem metricsSystem = constructorArguments.metricsSystem();
     // create counters
     this.requestedCounter =
         metricsSystem.createCounter(
@@ -105,7 +97,6 @@ public class EngineGetBlobsV3 extends ExecutionEngineJsonRpcMethod {
             BesuMetricCategory.RPC,
             "execution_engine_getblobs_v3_full_total",
             "Number of calls to engine_getBlobsV3 that returned complete responses");
-    this.osakaMilestone = protocolSchedule.milestoneFor(OSAKA);
   }
 
   @Override
@@ -191,10 +182,5 @@ public class EngineGetBlobsV3 extends ExecutionEngineJsonRpcMethod {
         blobProofBundle.getKzgProof().parallelStream()
             .map(proof -> HexUtils.toFastHex(proof.getData(), true))
             .toList());
-  }
-
-  @Override
-  protected ValidationResult<RpcErrorType> validateForkSupported(final long currentTimestamp) {
-    return ForkSupportHelper.validateForkSupported(OSAKA, osakaMilestone, currentTimestamp);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetClientVersionV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetClientVersionV1.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.datatypes.HardforkId;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
@@ -25,8 +25,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineGetClien
 import java.util.Collections;
 import java.util.List;
 
-import io.vertx.core.Vertx;
-
 public class EngineGetClientVersionV1 extends ExecutionEngineJsonRpcMethod {
   private static final String ENGINE_CLIENT_CODE = "BU";
   private static final String ENGINE_CLIENT_NAME = "Besu";
@@ -35,14 +33,12 @@ public class EngineGetClientVersionV1 extends ExecutionEngineJsonRpcMethod {
   private final String commit;
 
   public EngineGetClientVersionV1(
-      final Vertx vertx,
-      final ProtocolContext protocolContext,
-      final EngineCallListener engineCallListener,
-      final String clientVersion,
-      final String commit) {
-    super(vertx, protocolContext, engineCallListener);
-    this.clientVersion = clientVersion;
-    this.commit = commit;
+      final ConstructorArguments constructorArguments,
+      final HardforkId minSupportedFork,
+      final HardforkId firstUnsupportedFork) {
+    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    this.clientVersion = constructorArguments.clientVersion();
+    this.commit = constructorArguments.commit();
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
@@ -30,7 +30,7 @@ import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcRequestException;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.OrderedExecutionJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ExecutionPayloadV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.NewPayloadRequestParametersV1;
@@ -67,9 +67,16 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Extends {@link OrderedExecutionJsonRpcMethod} so that {@code engine_newPayload} calls (and those
+ * of the whole sealed V1-V5 hierarchy) are processed in the order they have been received,
+ * consistent with {@code engine_forkchoiceUpdated}: both affect canonical chain state and a
+ * newPayload racing ahead of (or behind) an FCU for the same or a related block could otherwise be
+ * observed out of order.
+ */
 public sealed class EngineNewPayloadV1<
         EP extends ExecutionPayloadV1, NPRP extends NewPayloadRequestParametersV1<? extends EP>>
-    extends ExecutionEngineJsonRpcMethod permits EngineNewPayloadV2 {
+    extends OrderedExecutionJsonRpcMethod permits EngineNewPayloadV2 {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineNewPayloadV1.class);
   private static final Hash OMMERS_HASH_CONSTANT = Hash.EMPTY_LIST_HASH;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
@@ -62,6 +62,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Preconditions;
+import io.vertx.core.Vertx;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -93,9 +94,10 @@ public sealed class EngineNewPayloadV1<
 
   public EngineNewPayloadV1(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
-    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    super(constructorArguments, vertx, minSupportedFork, firstUnsupportedFork);
     this.mergeCoordinator = constructorArguments.mergeCoordinator();
     this.ethPeers = constructorArguments.ethPeers();
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,9 +48,10 @@ public sealed class EngineNewPayloadV2<
 
   public EngineNewPayloadV2(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
-    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    super(constructorArguments, vertx, minSupportedFork, firstUnsupportedFork);
     shanghaiTimestamp = protocolSchedule.milestoneFor(HardforkId.MainnetHardforkId.SHANGHAI);
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,9 +57,10 @@ public sealed class EngineNewPayloadV3<
 
   public EngineNewPayloadV3(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
-    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    super(constructorArguments, vertx, minSupportedFork, firstUnsupportedFork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,9 +48,10 @@ public sealed class EngineNewPayloadV4<
 
   public EngineNewPayloadV4(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
-    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    super(constructorArguments, vertx, minSupportedFork, firstUnsupportedFork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
+import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +43,10 @@ public final class EngineNewPayloadV5<
 
   public EngineNewPayloadV5(
       final ConstructorArguments constructorArguments,
+      final Vertx vertx,
       final HardforkId minSupportedFork,
       final HardforkId firstUnsupportedFork) {
-    super(constructorArguments, minSupportedFork, firstUnsupportedFork);
+    super(constructorArguments, vertx, minSupportedFork, firstUnsupportedFork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
@@ -40,6 +40,15 @@ version adds or changes.
 - All versions extend `ExecutionEngineJsonRpcMethod`, which owns the fork-window validation
   (`minSupportedFork` / `firstUnsupportedFork` constructor arguments, `validateForkSupported`,
   see also `ForkSupportHelper`). Concrete versions never check fork timestamps themselves.
+- Engine methods execute concurrently by default. The `engine_forkchoiceUpdatedV*` and
+  `engine_newPayloadV*` series are the exception: the Engine API spec requires them to be
+  processed in the order they were received, so `EngineForkchoiceUpdatedV1` and
+  `EngineNewPayloadV1` extend `OrderedExecutionJsonRpcMethod` instead of
+  `ExecutionEngineJsonRpcMethod` directly — a compile-time choice, not a runtime flag, so a new
+  ordered series must extend `OrderedExecutionJsonRpcMethod` from its V1 class onward.
+  `OrderedExecutionJsonRpcMethod` runs calls through a single-threaded `WorkerExecutor` created
+  from the engine consensus API's existing Vertx instance (`ConstructorArguments.vertx()` — the
+  same one backing `EngineQosTimer`), rather than a dedicated Vertx instance just for ordering.
 - Migrated series take a single `ExecutionEngineJsonRpcMethod.ConstructorArguments` record (built
   via the generated `ConstructorArgumentsBuilder`) plus `(minSupportedFork, firstUnsupportedFork)`,
   instead of a bespoke positional argument list per series — this is what lets `VersionScheduler`

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
@@ -47,8 +47,10 @@ version adds or changes.
   `ExecutionEngineJsonRpcMethod` directly — a compile-time choice, not a runtime flag, so a new
   ordered series must extend `OrderedExecutionJsonRpcMethod` from its V1 class onward.
   `OrderedExecutionJsonRpcMethod` runs calls through a single-threaded `WorkerExecutor` created
-  from the engine consensus API's existing Vertx instance (`ConstructorArguments.vertx()` — the
-  same one backing `EngineQosTimer`), rather than a dedicated Vertx instance just for ordering.
+  from the engine consensus API's existing Vertx instance (the same one backing `EngineQosTimer`),
+  rather than a dedicated Vertx instance just for ordering. That instance is passed as an explicit
+  constructor argument rather than through `ConstructorArguments`, since FCU and newPayload are the
+  only series that need it.
 - Migrated series take a single `ExecutionEngineJsonRpcMethod.ConstructorArguments` record (built
   via the generated `ConstructorArgumentsBuilder`) plus `(minSupportedFork, firstUnsupportedFork)`,
   instead of a bespoke positional argument list per series — this is what lets `VersionScheduler`

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/README.md
@@ -5,38 +5,23 @@ This package implements the [Engine API](https://github.com/ethereum/execution-a
 version of a method — or a brand-new method series — is always added the same way. Read this before
 changing anything in this package, in the related parameter/result classes, or in their tests.
 
-## Migration status
+## Architecture
 
-Not every series has been migrated to the pattern below yet — the migration is landing series by
-series, each in its own PR, to keep changes reviewable:
-
-| Series | Constructor takes `ConstructorArguments`? | Registered via `VersionScheduler`? |
-|---|---|---|
-| `engine_forkchoiceUpdatedV*` | Yes | Yes |
-| `engine_newPayloadV*` | Yes | Yes |
-| `engine_getPayloadV*` | Yes | Yes |
-| `engine_getPayloadBodiesBy*` | Yes | Yes |
-| `engine_getBlobsV*`, `engine_exchangeCapabilities`, `engine_preparePayloadDebug`, `engine_getClientVersionV1`, `engine_exchangeTransitionConfigurationV1` | Not yet | Not yet |
-
-The not-yet-migrated series still take their old flat constructor argument list (some via
-`ExecutionEngineJsonRpcMethod`'s TRANSITIONAL SHIM constructors, kept until every series has moved
-over) and are registered in `ExecutionEngineJsonRpcMethods.create()` via plain `Arrays.asList(...)`
-plus manual `protocolSchedule.milestoneFor(FORK).isPresent()` checks. When migrating one of them,
-follow the pattern below and update this table.
-
-## Architecture (migrated series)
-
-Each method series (`engine_forkchoiceUpdatedV*`, `engine_newPayloadV*`, `engine_getPayloadV*`,
-`engine_getPayloadBodiesBy*` — see the migration status table above) is a **sealed class hierarchy
-mirroring the specification**: version N extends version N−1 and overrides only what its spec
-version adds or changes.
+Every series in this package follows the same pattern below, whether or not it has multiple
+versions. Series with more than one version (`engine_forkchoiceUpdatedV*`, `engine_newPayloadV*`,
+`engine_getPayloadV*`, `engine_getPayloadBodiesBy*`) are a **sealed class hierarchy mirroring the
+specification**: version N extends version N−1 and overrides only what its spec version adds or
+changes. Single-version series (`engine_exchangeCapabilities`, `engine_exchangeTransitionConfiguration`,
+`engine_getClientVersionV1`, `engine_getBlobsV*`) are a plain, non-sealed
+`ExecutionEngineJsonRpcMethod` subclass built with a `(null, null)` fork window (or, for
+`engine_getBlobsV*`, a real fork window, since those methods only activate from a given hardfork).
 
 - `EngineForkchoiceUpdatedV1 permits EngineForkchoiceUpdatedV2`, `... V3 permits
   EngineForkchoiceUpdatedV4`; `EngineNewPayloadV1 permits EngineNewPayloadV2`, `... V4 permits
   EngineNewPayloadV5`; `EngineGetPayloadV1 permits EngineGetPayloadV2`, `... V5 permits
   EngineGetPayloadV6`; `EngineGetPayloadBodiesByHashV1 permits EngineGetPayloadBodiesByHashV2` and
   `EngineGetPayloadBodiesByRangeV1 permits EngineGetPayloadBodiesByRangeV2`; and the latest version
-  of each is `final`. Future migrated series follow the same shape.
+  of each is `final`. Future multi-version series follow the same shape.
 - All versions extend `ExecutionEngineJsonRpcMethod`, which owns the fork-window validation
   (`minSupportedFork` / `firstUnsupportedFork` constructor arguments, `validateForkSupported`,
   see also `ForkSupportHelper`). Concrete versions never check fork timestamps themselves.
@@ -51,14 +36,16 @@ version adds or changes.
   rather than a dedicated Vertx instance just for ordering. That instance is passed as an explicit
   constructor argument rather than through `ConstructorArguments`, since FCU and newPayload are the
   only series that need it.
-- Migrated series take a single `ExecutionEngineJsonRpcMethod.ConstructorArguments` record (built
-  via the generated `ConstructorArgumentsBuilder`) plus `(minSupportedFork, firstUnsupportedFork)`,
+- Every series takes a single `ExecutionEngineJsonRpcMethod.ConstructorArguments` record (built via
+  the generated `ConstructorArgumentsBuilder`) plus `(minSupportedFork, firstUnsupportedFork)`,
   instead of a bespoke positional argument list per series — this is what lets `VersionScheduler`
-  build every version through one shared factory shape (see below). `ConstructorArguments` only
-  carries the fields the currently-migrated series need — mark a field `@Nullable` if only some
-  migrated series read it (e.g. `ethPeers`/`metricsSystem` are `engine_newPayloadV*`-only) — and
-  extend it (and its builder) when migrating a series that needs a field it doesn't have yet.
-- The JSON data structures relevant to migrated series are sealed hierarchies too, mirroring the
+  build every multi-version series through one shared factory shape (see below), and what lets a
+  single-version series be built with a one-line `new EngineFooV1(constructorArguments, from, to)`.
+  `ConstructorArguments` carries every field any series needs; mark a field `@Nullable` if only some
+  series read it (e.g. `mergeCoordinator` is absent pre-merge; `clientVersion`/`commit` are
+  `engine_getClientVersionV1`-only; `transactionPool` is `engine_getBlobsV*`-only) — and extend it
+  (and its builder) when adding a series that needs a field it doesn't have yet.
+- The JSON data structures relevant to multi-version series are sealed hierarchies too, mirroring the
   spec versions: request parameters in `..internal.parameters` (`ExecutionPayloadV1..V4`,
   `NewPayloadRequestParametersV1..V3`, `ForkchoiceStateV1`, `PayloadAttributesV1..V4`), results in
   `..internal.results` (`PayloadStatusV1`, `ForkchoiceUpdatedResultV1`,
@@ -72,16 +59,21 @@ version adds or changes.
 ### Registration and scheduling
 
 `org.hyperledger.besu.ethereum.api.jsonrpc.methods.ExecutionEngineJsonRpcMethods` declares, per
-migrated series, which version is active in which fork window via the `VersionScheduler` DSL, using
-constructor references (not reflection — see `VersionScheduler.EngineMethodFactory`):
+multi-version series, which version is active in which fork window via the `VersionScheduler` DSL,
+using constructor references (not reflection — see `VersionScheduler.EngineMethodFactory`):
 
 ```java
-VersionScheduler.startsFromBeginningUntil(EngineForkchoiceUpdatedV1::new, SHANGHAI)
-    .thenAlsoFromBeginning(EngineForkchoiceUpdatedV2::new)
-    .thenFrom(CANCUN, EngineForkchoiceUpdatedV3::new)
-    .thenFrom(AMSTERDAM, EngineForkchoiceUpdatedV4::new)
+VersionScheduler.startsFromBeginningUntil(EngineGetPayloadV1::new, SHANGHAI)
+    .thenAlsoFromBeginning(EngineGetPayloadV2::new)
+    .thenFrom(CANCUN, EngineGetPayloadV3::new)
+    .thenFrom(AMSTERDAM, EngineGetPayloadV6::new)
     .build(constructorArguments);
 ```
+
+`EngineForkchoiceUpdatedV*` and `EngineNewPayloadV*` follow the same DSL, but since their
+constructors take an extra `Vertx` argument (see `OrderedExecutionJsonRpcMethod` above), their
+factories are lambdas capturing `consensusEngineServer` instead of bare constructor references:
+`(ca, from, to) -> new EngineForkchoiceUpdatedV1<>(ca, consensusEngineServer, from, to)`.
 
 Not every series is a version-supersedes-version chain: in `engine_getPayloadBodiesBy*` V2 only adds
 an optional field, so V1 and V2 coexist permanently, with no fork window on either — use
@@ -89,9 +81,12 @@ an optional field, so V1 and V2 coexist permanently, with no fork window on eith
 for series like this instead of `startsFromBeginningUntil`/`thenFrom`.
 
 The scheduler instantiates each version with the right `(minSupportedFork, firstUnsupportedFork)`
-pair derived from the chain. Method names live in the `RpcMethod` enum;
-`engine_exchangeCapabilities` derives the advertised capability list automatically from every
-`RpcMethod` entry starting with `engine_`, so there is no separate capabilities list to maintain.
+pair derived from the chain. Single-version series aren't registered through `VersionScheduler` at
+all — `ExecutionEngineJsonRpcMethods.create()` just calls their constructor directly (e.g. `new
+EngineGetBlobsV1(constructorArguments, CANCUN, OSAKA)`), since there's no chain to build. Method
+names live in the `RpcMethod` enum; `engine_exchangeCapabilities` derives the advertised capability
+list automatically from every `RpcMethod` entry starting with `engine_`, so there is no separate
+capabilities list to maintain.
 
 ## Test pattern (src/test, same package)
 
@@ -117,7 +112,7 @@ Acceptance tests are fixture-driven, one directory per fork:
 `genesis.json` and `test-cases/` with JSON request/response pairs (see also the
 `*AcceptanceTestHelper` classes under `acceptance-tests/.../acceptance/ethereum/`).
 
-## Checklist: add version N+1 to an existing migrated series
+## Checklist: add version N+1 to an existing series
 
 Use the commits that introduced the current latest version as the exemplar
 (`git log --oneline -- <path to latest version class>`), then:
@@ -137,15 +132,19 @@ Use the commits that introduced the current latest version as the exemplar
 6. Add/extend the acceptance-test fixtures for the activation fork.
 7. Update `CHANGELOG.md`.
 
-## Checklist: add a brand-new method series (migrated pattern)
+## Checklist: add a brand-new method series
 
-1. Create `EngineBarV1 extends ExecutionEngineJsonRpcMethod` (sealed once V2 exists), taking
-   `ConstructorArguments` plus the fork window in its constructor; add its parameter/result classes
-   as (future-sealed) hierarchies from the start.
-2. Register it in `RpcMethod` and in `ExecutionEngineJsonRpcMethods` via `VersionScheduler`
-   (`startsFrom(<FORK>, EngineBarV1::new)` or `alwaysActive(...)`).
+1. Create `EngineBarV1 extends ExecutionEngineJsonRpcMethod` (sealed once V2 exists, otherwise
+   plain), taking `ConstructorArguments` plus the fork window in its constructor; add its
+   parameter/result classes as (future-sealed) hierarchies from the start if it takes/returns
+   structured data.
+2. Register it in `RpcMethod` and in `ExecutionEngineJsonRpcMethods`: via `VersionScheduler`
+   (`startsFrom(<FORK>, EngineBarV1::new)` or `alwaysActive(...)`) if more versions are expected, or
+   a direct `new EngineBarV1(constructorArguments, from, to)` call if it's a single-version series.
+   Extend `ConstructorArguments` (and its builder) first if it needs a field the record doesn't
+   carry yet — mark it `@Nullable` if no other series reads it.
 3. Create `EngineBarV1Test` with all scenarios written against protected hooks from day one, so
-   `EngineBarV2Test` can be layered on top later.
+   `EngineBarV2Test` can be layered on top later if a V2 is ever added.
 4. Add acceptance-test fixtures and a `CHANGELOG.md` entry.
 
 ## Definition of done

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -121,7 +121,6 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
           new ConstructorArguments(
               protocolSchedule,
               protocolContext,
-              consensusEngineServer,
               engineQosTimer,
               mergeCoordinator.get(),
               ethPeers,
@@ -183,24 +182,43 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private Collection<? extends JsonRpcMethod> createEngineForkchoiceUpdatedMethods(
       final ConstructorArguments constructorArguments) {
 
+    // FCU is the only engine method series (besides engine_newPayload) requiring ordered
+    // execution, so it's the only one whose factories need the shared consensus engine Vertx
+    // instance — captured here rather than threaded through ConstructorArguments.
     // special case at the first hardfork (Shanghai), before it was possible to call either V1 or V2
     // so both versions are scheduled at the beginning, and only V1 must be stopped at Shanghai
     // timestamp
-    return VersionScheduler.startsFromBeginningUntil(EngineForkchoiceUpdatedV1::new, SHANGHAI)
-        .thenAlsoFromBeginning(EngineForkchoiceUpdatedV2::new)
-        .thenFrom(CANCUN, EngineForkchoiceUpdatedV3::new)
-        .thenFrom(AMSTERDAM, EngineForkchoiceUpdatedV4::new)
+    return VersionScheduler.startsFromBeginningUntil(
+            (ca, from, to) -> new EngineForkchoiceUpdatedV1<>(ca, consensusEngineServer, from, to),
+            SHANGHAI)
+        .thenAlsoFromBeginning(
+            (ca, from, to) -> new EngineForkchoiceUpdatedV2<>(ca, consensusEngineServer, from, to))
+        .thenFrom(
+            CANCUN,
+            (ca, from, to) -> new EngineForkchoiceUpdatedV3<>(ca, consensusEngineServer, from, to))
+        .thenFrom(
+            AMSTERDAM,
+            (ca, from, to) -> new EngineForkchoiceUpdatedV4<>(ca, consensusEngineServer, from, to))
         .build(constructorArguments);
   }
 
   private Collection<? extends JsonRpcMethod> createEngineNewPayloadMethods(
       final ConstructorArguments constructorArguments) {
 
-    return VersionScheduler.startsFromBeginningUntil(EngineNewPayloadV1::new, SHANGHAI)
-        .thenAlsoFromBeginning(EngineNewPayloadV2::new)
-        .thenFrom(CANCUN, EngineNewPayloadV3::new)
-        .thenFrom(PRAGUE, EngineNewPayloadV4::new)
-        .thenFrom(AMSTERDAM, EngineNewPayloadV5::new)
+    // engine_newPayload also requires ordered execution — see the comment in
+    // createEngineForkchoiceUpdatedMethods above.
+    return VersionScheduler.startsFromBeginningUntil(
+            (ca, from, to) -> new EngineNewPayloadV1<>(ca, consensusEngineServer, from, to),
+            SHANGHAI)
+        .thenAlsoFromBeginning(
+            (ca, from, to) -> new EngineNewPayloadV2<>(ca, consensusEngineServer, from, to))
+        .thenFrom(
+            CANCUN, (ca, from, to) -> new EngineNewPayloadV3<>(ca, consensusEngineServer, from, to))
+        .thenFrom(
+            PRAGUE, (ca, from, to) -> new EngineNewPayloadV4<>(ca, consensusEngineServer, from, to))
+        .thenFrom(
+            AMSTERDAM,
+            (ca, from, to) -> new EngineNewPayloadV5<>(ca, consensusEngineServer, from, to))
         .build(constructorArguments);
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -116,17 +116,22 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
   @Override
   protected Map<String, JsonRpcMethod> create() {
     final EngineQosTimer engineQosTimer = new EngineQosTimer(consensusEngineServer);
-    if (mergeCoordinator.isPresent()) {
-      final ConstructorArguments constructorArguments =
-          new ConstructorArguments(
-              protocolSchedule,
-              protocolContext,
-              engineQosTimer,
-              mergeCoordinator.get(),
-              ethPeers,
-              metricsSystem,
-              GET_PAYLOAD_BODIES_MAX_REQUEST_SIZE);
+    // mergeCoordinator is absent pre-merge, when only EngineExchangeTransitionConfiguration is
+    // registered (see the else branch below) — every other field is always available.
+    final ConstructorArguments constructorArguments =
+        new ConstructorArguments(
+            protocolSchedule,
+            protocolContext,
+            engineQosTimer,
+            mergeCoordinator.orElse(null),
+            ethPeers,
+            metricsSystem,
+            GET_PAYLOAD_BODIES_MAX_REQUEST_SIZE,
+            clientVersion,
+            commit,
+            transactionPool);
 
+    if (mergeCoordinator.isPresent()) {
       List<JsonRpcMethod> executionEngineApisSupported = new ArrayList<>();
       executionEngineApisSupported.addAll(
           createEngineForkchoiceUpdatedMethods(constructorArguments));
@@ -139,43 +144,19 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
       executionEngineApisSupported.addAll(
           Arrays.asList(
-              new EngineExchangeTransitionConfiguration(
-                  consensusEngineServer, protocolContext, engineQosTimer),
-              new EngineExchangeCapabilities(
-                  consensusEngineServer, protocolContext, engineQosTimer),
-              new EngineGetClientVersionV1(
-                  consensusEngineServer, protocolContext, engineQosTimer, clientVersion, commit),
-              new EngineGetBlobsV1(
-                  consensusEngineServer,
-                  protocolContext,
-                  protocolSchedule,
-                  engineQosTimer,
-                  transactionPool)));
+              new EngineExchangeTransitionConfiguration(constructorArguments, null, null),
+              new EngineExchangeCapabilities(constructorArguments, null, null),
+              new EngineGetClientVersionV1(constructorArguments, null, null),
+              new EngineGetBlobsV1(constructorArguments, CANCUN, OSAKA)));
 
       if (protocolSchedule.milestoneFor(OSAKA).isPresent()) {
-        executionEngineApisSupported.add(
-            new EngineGetBlobsV2(
-                consensusEngineServer,
-                protocolContext,
-                protocolSchedule,
-                engineQosTimer,
-                transactionPool,
-                metricsSystem));
-        executionEngineApisSupported.add(
-            new EngineGetBlobsV3(
-                consensusEngineServer,
-                protocolContext,
-                protocolSchedule,
-                engineQosTimer,
-                transactionPool,
-                metricsSystem));
+        executionEngineApisSupported.add(new EngineGetBlobsV2(constructorArguments, OSAKA, null));
+        executionEngineApisSupported.add(new EngineGetBlobsV3(constructorArguments, OSAKA, null));
       }
 
       return mapOf(executionEngineApisSupported);
     } else {
-      return mapOf(
-          new EngineExchangeTransitionConfiguration(
-              consensusEngineServer, protocolContext, engineQosTimer));
+      return mapOf(new EngineExchangeTransitionConfiguration(constructorArguments, null, null));
     }
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineCallListener;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.ArrayList;
@@ -49,6 +53,12 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
 
   @Mock private EngineCallListener engineCallListener;
 
+  @Mock private ProtocolSchedule protocolSchedule;
+
+  @Mock private MergeMiningCoordinator mergeCoordinator;
+
+  @Mock private EthPeers ethPeers;
+
   @AfterAll
   public static void tearDown() {
     vertx.close();
@@ -59,11 +69,10 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     // each call blocks until the other one has started executing, so the test only
     // completes if the two calls run in parallel
     final CyclicBarrier bothStarted = new CyclicBarrier(2);
-    final StubEngineMethod method =
-        new StubEngineMethod(
+    final UnorderedStubEngineMethod method =
+        new UnorderedStubEngineMethod(
             protocolContext,
             engineCallListener,
-            false,
             req -> {
               try {
                 bothStarted.await(10, TimeUnit.SECONDS);
@@ -82,11 +91,13 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
   public void orderedMethodCallsNeverExecuteConcurrently() throws Exception {
     final AtomicInteger active = new AtomicInteger();
     final AtomicInteger maxActive = new AtomicInteger();
-    final StubEngineMethod method =
-        new StubEngineMethod(
+    final OrderedStubEngineMethod method =
+        new OrderedStubEngineMethod(
+            protocolSchedule,
             protocolContext,
             engineCallListener,
-            true,
+            mergeCoordinator,
+            ethPeers,
             req -> {
               maxActive.accumulateAndGet(active.incrementAndGet(), Math::max);
               try {
@@ -104,7 +115,7 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     assertThat(maxActive.get()).isEqualTo(1);
   }
 
-  private List<JsonRpcResponse> callConcurrently(final StubEngineMethod method, final int callers)
+  private List<JsonRpcResponse> callConcurrently(final JsonRpcMethod method, final int callers)
       throws Exception {
     final ExecutorService pool = Executors.newFixedThreadPool(callers);
     try {
@@ -127,28 +138,57 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     }
   }
 
-  private static class StubEngineMethod extends ExecutionEngineJsonRpcMethod {
-    private final boolean ordered;
+  private static class UnorderedStubEngineMethod extends ExecutionEngineJsonRpcMethod {
     private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
 
-    StubEngineMethod(
+    UnorderedStubEngineMethod(
         final ProtocolContext protocolContext,
         final EngineCallListener engineCallListener,
-        final boolean ordered,
         final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
       super(vertx, protocolContext, engineCallListener);
-      this.ordered = ordered;
       this.body = body;
     }
 
     @Override
     public String getName() {
-      return "engine_stub";
+      return "engine_stub_unordered";
     }
 
     @Override
-    protected boolean requiresOrderedExecution() {
-      return ordered;
+    public JsonRpcResponse syncResponse(final JsonRpcRequestContext request) {
+      return body.apply(request);
+    }
+  }
+
+  private static class OrderedStubEngineMethod extends OrderedExecutionJsonRpcMethod {
+    private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
+
+    OrderedStubEngineMethod(
+        final ProtocolSchedule protocolSchedule,
+        final ProtocolContext protocolContext,
+        final EngineCallListener engineCallListener,
+        final MergeMiningCoordinator mergeCoordinator,
+        final EthPeers ethPeers,
+        final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
+      super(
+          new ConstructorArgumentsBuilder()
+              .protocolSchedule(protocolSchedule)
+              .protocolContext(protocolContext)
+              .vertx(vertx)
+              .engineCallListener(engineCallListener)
+              .mergeCoordinator(mergeCoordinator)
+              .ethPeers(ethPeers)
+              .metricsSystem(new NoOpMetricsSystem())
+              .maxRequestBlocks(0)
+              .build(),
+          null,
+          null);
+      this.body = body;
+    }
+
+    @Override
+    public String getName() {
+      return "engine_stub_ordered";
     }
 
     @Override

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineCallListener;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ExecutionEngineJsonRpcMethodExecutionTest {
+  private static final Vertx vertx = Vertx.vertx();
+
+  @Mock private ProtocolContext protocolContext;
+
+  @Mock private EngineCallListener engineCallListener;
+
+  @AfterAll
+  public static void tearDown() {
+    vertx.close();
+  }
+
+  @Test
+  public void unorderedMethodCallsExecuteConcurrently() throws Exception {
+    // each call blocks until the other one has started executing, so the test only
+    // completes if the two calls run in parallel
+    final CyclicBarrier bothStarted = new CyclicBarrier(2);
+    final StubEngineMethod method =
+        new StubEngineMethod(
+            protocolContext,
+            engineCallListener,
+            false,
+            req -> {
+              try {
+                bothStarted.await(10, TimeUnit.SECONDS);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return new JsonRpcSuccessResponse(req.getRequest().getId());
+            });
+
+    final List<JsonRpcResponse> responses = callConcurrently(method, 2);
+
+    assertThat(responses).allMatch(resp -> resp.getType() == RpcResponseType.SUCCESS);
+  }
+
+  @Test
+  public void orderedMethodCallsNeverExecuteConcurrently() throws Exception {
+    final AtomicInteger active = new AtomicInteger();
+    final AtomicInteger maxActive = new AtomicInteger();
+    final StubEngineMethod method =
+        new StubEngineMethod(
+            protocolContext,
+            engineCallListener,
+            true,
+            req -> {
+              maxActive.accumulateAndGet(active.incrementAndGet(), Math::max);
+              try {
+                Thread.sleep(50);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              active.decrementAndGet();
+              return new JsonRpcSuccessResponse(req.getRequest().getId());
+            });
+
+    final List<JsonRpcResponse> responses = callConcurrently(method, 4);
+
+    assertThat(responses).allMatch(resp -> resp.getType() == RpcResponseType.SUCCESS);
+    assertThat(maxActive.get()).isEqualTo(1);
+  }
+
+  private List<JsonRpcResponse> callConcurrently(final StubEngineMethod method, final int callers)
+      throws Exception {
+    final ExecutorService pool = Executors.newFixedThreadPool(callers);
+    try {
+      final List<Future<JsonRpcResponse>> futures = new ArrayList<>();
+      for (int i = 0; i < callers; i++) {
+        futures.add(
+            pool.submit(
+                () ->
+                    method.response(
+                        new JsonRpcRequestContext(
+                            new JsonRpcRequest("2.0", method.getName(), new Object[0])))));
+      }
+      final List<JsonRpcResponse> responses = new ArrayList<>(callers);
+      for (final Future<JsonRpcResponse> future : futures) {
+        responses.add(future.get(30, TimeUnit.SECONDS));
+      }
+      return responses;
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  private static class StubEngineMethod extends ExecutionEngineJsonRpcMethod {
+    private final boolean ordered;
+    private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
+
+    StubEngineMethod(
+        final ProtocolContext protocolContext,
+        final EngineCallListener engineCallListener,
+        final boolean ordered,
+        final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
+      super(vertx, protocolContext, engineCallListener);
+      this.ordered = ordered;
+      this.body = body;
+    }
+
+    @Override
+    public String getName() {
+      return "engine_stub";
+    }
+
+    @Override
+    protected boolean requiresOrderedExecution() {
+      return ordered;
+    }
+
+    @Override
+    public JsonRpcResponse syncResponse(final JsonRpcRequestContext request) {
+      return body.apply(request);
+    }
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
@@ -174,13 +174,13 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
           new ConstructorArgumentsBuilder()
               .protocolSchedule(protocolSchedule)
               .protocolContext(protocolContext)
-              .vertx(vertx)
               .engineCallListener(engineCallListener)
               .mergeCoordinator(mergeCoordinator)
               .ethPeers(ethPeers)
               .metricsSystem(new NoOpMetricsSystem())
               .maxRequestBlocks(0)
               .build(),
+          vertx,
           null,
           null);
       this.body = body;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethodExecutionTest.java
@@ -71,8 +71,10 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     final CyclicBarrier bothStarted = new CyclicBarrier(2);
     final UnorderedStubEngineMethod method =
         new UnorderedStubEngineMethod(
+            protocolSchedule,
             protocolContext,
             engineCallListener,
+            ethPeers,
             req -> {
               try {
                 bothStarted.await(10, TimeUnit.SECONDS);
@@ -142,10 +144,22 @@ public class ExecutionEngineJsonRpcMethodExecutionTest {
     private final Function<JsonRpcRequestContext, JsonRpcResponse> body;
 
     UnorderedStubEngineMethod(
+        final ProtocolSchedule protocolSchedule,
         final ProtocolContext protocolContext,
         final EngineCallListener engineCallListener,
+        final EthPeers ethPeers,
         final Function<JsonRpcRequestContext, JsonRpcResponse> body) {
-      super(vertx, protocolContext, engineCallListener);
+      super(
+          new ConstructorArgumentsBuilder()
+              .protocolSchedule(protocolSchedule)
+              .protocolContext(protocolContext)
+              .engineCallListener(engineCallListener)
+              .ethPeers(ethPeers)
+              .metricsSystem(new NoOpMetricsSystem())
+              .maxRequestBlocks(0)
+              .build(),
+          null,
+          null);
       this.body = body;
     }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilitiesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilitiesTest.java
@@ -22,15 +22,18 @@ import static org.mockito.Mockito.verify;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,15 +43,29 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class EngineExchangeCapabilitiesTest {
   private EngineExchangeCapabilities method;
-  private static final Vertx vertx = Vertx.vertx();
 
   @Mock private ProtocolContext protocolContext;
 
   @Mock private EngineCallListener engineCallListener;
 
+  @Mock private ProtocolSchedule protocolSchedule;
+
+  @Mock private EthPeers ethPeers;
+
   @BeforeEach
   public void setUp() {
-    this.method = new EngineExchangeCapabilities(vertx, protocolContext, engineCallListener);
+    this.method =
+        new EngineExchangeCapabilities(
+            new ConstructorArgumentsBuilder()
+                .protocolSchedule(protocolSchedule)
+                .protocolContext(protocolContext)
+                .engineCallListener(engineCallListener)
+                .ethPeers(ethPeers)
+                .metricsSystem(new NoOpMetricsSystem())
+                .maxRequestBlocks(0)
+                .build(),
+            null,
+            null);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineExchangeTransitionConfigurationParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -38,6 +39,9 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ParsedExtraData;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.math.BigInteger;
@@ -46,7 +50,6 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -60,7 +63,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class EngineExchangeTransitionConfigurationTest {
   private EngineExchangeTransitionConfiguration method;
-  private static final Vertx vertx = Vertx.vertx();
 
   @Mock private ProtocolContext protocolContext;
 
@@ -68,12 +70,26 @@ public class EngineExchangeTransitionConfigurationTest {
 
   @Mock private EngineCallListener engineCallListener;
 
+  @Mock private ProtocolSchedule protocolSchedule;
+
+  @Mock private EthPeers ethPeers;
+
   @BeforeEach
   public void setUp() {
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
 
     this.method =
-        new EngineExchangeTransitionConfiguration(vertx, protocolContext, engineCallListener);
+        new EngineExchangeTransitionConfiguration(
+            new ConstructorArgumentsBuilder()
+                .protocolSchedule(protocolSchedule)
+                .protocolContext(protocolContext)
+                .engineCallListener(engineCallListener)
+                .ethPeers(ethPeers)
+                .metricsSystem(new NoOpMetricsSystem())
+                .maxRequestBlocks(0)
+                .build(),
+            null,
+            null);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedBadAncestorIntegrationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedBadAncestorIntegrationTest.java
@@ -138,13 +138,13 @@ public class EngineForkchoiceUpdatedBadAncestorIntegrationTest {
             new ConstructorArgumentsBuilder()
                 .protocolSchedule(protocolSchedule)
                 .protocolContext(protocolContext)
-                .vertx(vertx)
                 .engineCallListener(mock(EngineCallListener.class))
                 .mergeCoordinator(mergeCoordinator)
                 .ethPeers(mock(EthPeers.class))
                 .metricsSystem(new NoOpMetricsSystem())
                 .maxRequestBlocks(0)
                 .build(),
+            vertx,
             CANCUN,
             AMSTERDAM);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -113,13 +113,13 @@ public class EngineForkchoiceUpdatedV1Test extends AbstractScheduledApiTest {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(mock(EthPeers.class))
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         null,
         SHANGHAI);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -60,13 +60,13 @@ public class EngineForkchoiceUpdatedV2Test extends EngineForkchoiceUpdatedV1Test
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(mock(EthPeers.class))
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         PARIS,
         CANCUN);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3Test.java
@@ -53,13 +53,13 @@ public class EngineForkchoiceUpdatedV3Test extends EngineForkchoiceUpdatedV2Test
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(mock(EthPeers.class))
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         CANCUN,
         AMSTERDAM);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4Test.java
@@ -54,13 +54,13 @@ public class EngineForkchoiceUpdatedV4Test extends EngineForkchoiceUpdatedV3Test
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(mock(EthPeers.class))
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         AMSTERDAM,
         null);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV1Test.java
@@ -15,8 +15,11 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.CANCUN;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +37,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
@@ -44,7 +48,9 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.kzg.BlobsWithCommitments;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.math.BigInteger;
@@ -53,7 +59,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,8 +92,6 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
 
   private EngineGetBlobsV1 method;
 
-  private static final Vertx vertx = Vertx.vertx();
-
   @BeforeEach
   public void beforeEach() {
     when(mergeContext.isSyncing()).thenReturn(false);
@@ -100,7 +103,17 @@ public class EngineGetBlobsV1Test extends AbstractScheduledApiTest {
     this.method =
         spy(
             new EngineGetBlobsV1(
-                vertx, protocolContext, protocolSchedule, engineCallListener, transactionPool));
+                new ConstructorArgumentsBuilder()
+                    .protocolSchedule(protocolSchedule)
+                    .protocolContext(protocolContext)
+                    .engineCallListener(engineCallListener)
+                    .ethPeers(mock(EthPeers.class))
+                    .metricsSystem(new NoOpMetricsSystem())
+                    .maxRequestBlocks(0)
+                    .transactionPool(transactionPool)
+                    .build(),
+                CANCUN,
+                OSAKA));
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV2Test.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_CELL_PROOFS;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_PROOF;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,6 +34,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -43,6 +45,7 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlobTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
@@ -53,7 +56,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,12 +109,17 @@ public class EngineGetBlobsV2Test extends AbstractScheduledApiTest {
 
     method =
         new EngineGetBlobsV2(
-            mock(Vertx.class),
-            protocolContext,
-            protocolSchedule,
-            mock(EngineCallListener.class),
-            transactionPool,
-            metricsSystem);
+            new ConstructorArgumentsBuilder()
+                .protocolSchedule(protocolSchedule)
+                .protocolContext(protocolContext)
+                .engineCallListener(mock(EngineCallListener.class))
+                .ethPeers(mock(EthPeers.class))
+                .metricsSystem(metricsSystem)
+                .maxRequestBlocks(0)
+                .transactionPool(transactionPool)
+                .build(),
+            OSAKA,
+            null);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetBlobsV3Test.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_CELL_PROOFS;
 import static org.hyperledger.besu.datatypes.BlobType.KZG_PROOF;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.OSAKA;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineTestSupport.fromErrorResp;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,6 +34,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
@@ -41,6 +43,7 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlobTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.kzg.BlobProofBundle;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
@@ -51,7 +54,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,12 +109,17 @@ public class EngineGetBlobsV3Test extends AbstractScheduledApiTest {
 
     method =
         new EngineGetBlobsV3(
-            mock(Vertx.class),
-            protocolContext,
-            protocolSchedule,
-            mock(EngineCallListener.class),
-            transactionPool,
-            metricsSystem);
+            new ConstructorArgumentsBuilder()
+                .protocolSchedule(protocolSchedule)
+                .protocolContext(protocolContext)
+                .engineCallListener(mock(EngineCallListener.class))
+                .ethPeers(mock(EthPeers.class))
+                .metricsSystem(metricsSystem)
+                .maxRequestBlocks(0)
+                .transactionPool(transactionPool)
+                .build(),
+            OSAKA,
+            null);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetClientVersionV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetClientVersionV1Test.java
@@ -19,13 +19,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ConstructorArgumentsBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineGetClientVersionResultV1;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.util.List;
 
-import io.vertx.core.Vertx;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -44,11 +47,18 @@ class EngineGetClientVersionV1Test {
   void before() {
     getClientVersion =
         new EngineGetClientVersionV1(
-            Mockito.mock(Vertx.class),
-            Mockito.mock(ProtocolContext.class),
-            Mockito.mock(EngineCallListener.class),
-            CLIENT_VERSION,
-            COMMIT);
+            new ConstructorArgumentsBuilder()
+                .protocolSchedule(Mockito.mock(ProtocolSchedule.class))
+                .protocolContext(Mockito.mock(ProtocolContext.class))
+                .engineCallListener(Mockito.mock(EngineCallListener.class))
+                .ethPeers(Mockito.mock(EthPeers.class))
+                .metricsSystem(new NoOpMetricsSystem())
+                .maxRequestBlocks(0)
+                .clientVersion(CLIENT_VERSION)
+                .commit(COMMIT)
+                .build(),
+            null,
+            null);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV1Test.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +59,6 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineGetPayloadBodiesByHashV1Test extends AbstractScheduledApiTest {
   protected EngineGetPayloadBodiesByHashV1<?> method;
-  protected static final Vertx vertx = Vertx.vertx();
   @Mock protected ProtocolContext protocolContext;
   @Mock protected EngineCallListener engineCallListener;
   @Mock protected MutableBlockchain blockchain;
@@ -77,7 +75,6 @@ public class EngineGetPayloadBodiesByHashV1Test extends AbstractScheduledApiTest
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mock(MergeMiningCoordinator.class))
             .ethPeers(mock(EthPeers.class))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV2Test.java
@@ -55,7 +55,6 @@ public class EngineGetPayloadBodiesByHashV2Test extends EngineGetPayloadBodiesBy
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mock(MergeMiningCoordinator.class))
             .ethPeers(mock(EthPeers.class))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV1Test.java
@@ -49,7 +49,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +62,6 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineGetPayloadBodiesByRangeV1Test extends AbstractScheduledApiTest {
   protected EngineGetPayloadBodiesByRangeV1<?> method;
-  protected static final Vertx vertx = Vertx.vertx();
   @Mock protected ProtocolContext protocolContext;
   @Mock protected EngineCallListener engineCallListener;
   @Mock protected MutableBlockchain blockchain;
@@ -80,7 +78,6 @@ public class EngineGetPayloadBodiesByRangeV1Test extends AbstractScheduledApiTes
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mock(MergeMiningCoordinator.class))
             .ethPeers(mock(EthPeers.class))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV2Test.java
@@ -57,7 +57,6 @@ public class EngineGetPayloadBodiesByRangeV2Test extends EngineGetPayloadBodiesB
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mock(MergeMiningCoordinator.class))
             .ethPeers(mock(EthPeers.class))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV1Test.java
@@ -63,7 +63,6 @@ import java.util.OptionalLong;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,7 +80,6 @@ public class EngineGetPayloadV1Test extends AbstractScheduledApiTest {
 
   protected EngineGetPayloadV1 method;
 
-  protected static final Vertx vertx = Vertx.vertx();
   protected static final PayloadIdentifier mockPid = new PayloadIdentifier(1337L);
   protected BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
@@ -116,7 +114,6 @@ public class EngineGetPayloadV1Test extends AbstractScheduledApiTest {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeMiningCoordinator)
             .ethPeers(ethPeers)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2Test.java
@@ -51,7 +51,6 @@ public class EngineGetPayloadV2Test extends EngineGetPayloadV1Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeMiningCoordinator)
             .ethPeers(ethPeers)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
@@ -40,7 +40,6 @@ public class EngineGetPayloadV3Test extends EngineGetPayloadV2Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeMiningCoordinator)
             .ethPeers(ethPeers)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
@@ -55,7 +55,6 @@ public class EngineGetPayloadV4Test extends EngineGetPayloadV3Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeMiningCoordinator)
             .ethPeers(ethPeers)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV5Test.java
@@ -40,7 +40,6 @@ public class EngineGetPayloadV5Test extends EngineGetPayloadV4Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeMiningCoordinator)
             .ethPeers(ethPeers)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV6Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV6Test.java
@@ -62,7 +62,6 @@ public class EngineGetPayloadV6Test extends EngineGetPayloadV5Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeMiningCoordinator)
             .ethPeers(ethPeers)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
@@ -129,13 +129,13 @@ public class EngineNewPayloadV1Test extends AbstractScheduledApiTest {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         null,
         SHANGHAI);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2Test.java
@@ -61,13 +61,13 @@ public class EngineNewPayloadV2Test extends EngineNewPayloadV1Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         null,
         CANCUN);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
@@ -103,13 +103,13 @@ public class EngineNewPayloadV3Test extends EngineNewPayloadV2Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         CANCUN,
         PRAGUE);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
@@ -88,13 +88,13 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         PRAGUE,
         AMSTERDAM);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV5Test.java
@@ -67,13 +67,13 @@ public class EngineNewPayloadV5Test extends EngineNewPayloadV4Test {
         new ConstructorArgumentsBuilder()
             .protocolSchedule(protocolSchedule)
             .protocolContext(protocolContext)
-            .vertx(vertx)
             .engineCallListener(engineCallListener)
             .mergeCoordinator(mergeCoordinator)
             .ethPeers(ethPeers)
             .metricsSystem(new NoOpMetricsSystem())
             .maxRequestBlocks(0)
             .build(),
+        vertx,
         AMSTERDAM,
         BOGOTA);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/VersionSchedulerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/VersionSchedulerTest.java
@@ -37,7 +37,6 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import java.util.List;
 import java.util.Optional;
 
-import io.vertx.core.Vertx;
 import org.junit.jupiter.api.Test;
 
 class VersionSchedulerTest {
@@ -47,7 +46,6 @@ class VersionSchedulerTest {
       new ConstructorArgumentsBuilder()
           .protocolSchedule(protocolSchedule)
           .protocolContext(mock(ProtocolContext.class))
-          .vertx(mock(Vertx.class))
           .engineCallListener(mock(EngineCallListener.class))
           .mergeCoordinator(mock(MergeMiningCoordinator.class))
           .ethPeers(mock(EthPeers.class))


### PR DESCRIPTION
## PR description

includes: 
 * minimal pr #8 
 * constructor args pr #9 

and removes the shim constructors in ExecutionEngineJsonRpcMethod

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR if updates are required in the [Besu documentation](https://github.com/besu-eth/besu-docs).
- [ ] Considered the changelog and [included an update if required](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md#changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://github.com/besu-eth/besu/wiki/Working-through-Hive-tests)


